### PR TITLE
wasm: mark finalize_release.py as deprecated dead code

### DIFF
--- a/docs/contracts/en/release-artifact.md
+++ b/docs/contracts/en/release-artifact.md
@@ -71,6 +71,14 @@ guest module's binary artifact and its manifest declarations are produced and
 verified to be self-consistent *before* `finalize` checksums and signs the
 result.
 
+`tools/finalize_release.py` is **deprecated and dead code** on this path: it
+has no call site in `Makefile`, `mk/*.mk`, or `.github/workflows/*.yml`, and
+the **finalize** phase above is implemented by `tools.infra.ReleaseManager`
+(see `tools/infra.py:352-385`'s checksum + `buildHash` signing model), not by
+this script. It is retained only pending a relay-readiness milestone (cf.
+CIC-Schemas `compiler-architecture-plan.md`, "Step 10") and is marked
+`# DEPRECATED` in the module itself.
+
 ## Target state: provable signed release bundle
 
 The current implemented state — `buildHash` + `wasm.rebuild-verify` + ABI

--- a/docs/contracts/hu/release-artifact.md
+++ b/docs/contracts/hu/release-artifact.md
@@ -75,6 +75,15 @@ egy WASM guest modul bináris artifactja és a manifeszt-deklarációi
 előállnak és ellenőrizve lesz, hogy önkonzisztensek, *mielőtt* a
 `finalize` checksum-olja és aláírja az eredményt.
 
+A `tools/finalize_release.py` **deprecated és dead code** ezen az úton: nincs
+hívási helye a `Makefile`-ban, `mk/*.mk`-ban vagy
+`.github/workflows/*.yml`-ben, és a fenti **finalize** fázist a
+`tools.infra.ReleaseManager` implementálja (lásd `tools/infra.py:352-385`
+checksum + `buildHash` aláírási modelljét), nem ez a script. Csak egy
+relay-readiness milestone-ig marad meg (vö. CIC-Schemas
+`compiler-architecture-plan.md`, "Step 10"), és a modulban `# DEPRECATED`
+jelöléssel van ellátva.
+
 ## Célállapot: bizonyítható, aláírt release bundle
 
 A jelenlegi implementált állapot — `buildHash` + `wasm.rebuild-verify` + ABI

--- a/tools/finalize_release.py
+++ b/tools/finalize_release.py
@@ -14,6 +14,14 @@
 # Once that system is in place, this script will become obsolete and should be
 # removed.
 
+# DEPRECATED: This module is dead code on the production release path
+# (no Makefile/mk/*.mk/.github/workflows/*.yml call site — verified via
+# `grep -rn "finalize_release"`). The active release chain is
+# `make release` -> tools.compiler -> tools.infra.ReleaseManager
+# (see tools/infra.py:352-385 for the checksum+buildHash signing model).
+# Track relay-readiness as a separate milestone; delete this module on
+# relay GA (cf. CIC-Schemas compiler-architecture-plan.md, "Step 10").
+
 import argparse
 import base64
 import hashlib


### PR DESCRIPTION
## Summary
- `tools/finalize_release.py` jelölve `# DEPRECATED` blokkal — dead code a production release path-on (0 call site `Makefile`/`mk/*.mk`/`.github/workflows/*.yml`-ben).
- A `# FIXME` komment megmaradt (eredeti kontextus), a `# DEPRECATED` blokk kiegészíti (jelenlegi státusz).
- `docs/contracts/{en,hu}/release-artifact.md` megemlíti a deprecation-t, hivatkozva az aktív láncra (`tools.infra.ReleaseManager`, `tools/infra.py:352-385`).
- Minta: `CIC-Schemas/docs/en/compiler-architecture-plan.md` "Step 10 — Mark finalize_release.py for deletion".
- A modul és a tesztje (`tests/test_tools/test_finalize_release.py`) nem törölve — törlés a relay-GA milestone hatóköre.

## Test plan
- [x] `make test` → 112 passed, EXIT=0
- [x] `make check` → Black/Ruff/yamllint/MyPy/Bandit mind zöld, EXIT=0
- [x] `grep -rn "finalize_release" Makefile mk/*.mk .github/workflows/*.yml` → 0 találat (nincs új call site)

Forrás: `cic-factory` job `wasm-finalize-release-deprecation` (parent: `wasm-release-pipeline-audit`, opció A).