### PR TITLE
feat(server): in-process file watcher with in-memory incremental KB update

### DIFF
--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -22,14 +22,23 @@ import os
 import pickle
 import re
 import argparse
+import hashlib
+import json
+import threading
+import time
 import numpy as np
 import faiss
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 
 from mcp.server.fastmcp import FastMCP
 from sentence_transformers import SentenceTransformer
+
+# ── watch-mode globals ───────────────────────────────────────────────────────
+_kb: dict | None = None
+_kb_lock = threading.RLock()
+_watch_dir: Path | None = None
+_watch_interval: float = 2.0
 
 mcp = FastMCP("cic-graph")
 
@@ -95,19 +104,33 @@ def _normalize_line_range(val: Any) -> Optional[list[int]]:
     return None
 
 
-@lru_cache(maxsize=1)
 def load_kb() -> dict[str, Any]:
-    """Load all PKL artifacts into memory once."""
+    """Return the in-memory KB, loading from disk on first call."""
+    global _kb
+    with _kb_lock:
+        if _kb is None:
+            _kb = _load_kb_from_disk()
+        return _kb
+
+
+def _load_kb_from_disk() -> dict[str, Any]:
+    """Load all PKL artifacts from disk into a fresh dict."""
     def load_one(p: Path) -> Any:
         if not p.exists():
             raise FileNotFoundError(f"Missing: {p}")
         with p.open("rb") as f:
             return pickle.load(f)
 
+    def load_opt(p: Path, default: Any = None) -> Any:
+        if not p.exists():
+            return default
+        with p.open("rb") as f:
+            return pickle.load(f)
+
     chunks = load_one(CHUNKS_PKL)
-    nodes = load_one(NODES_PKL)
-    edges = load_one(EDGES_PKL)
-    inverted = load_one(INVERTED_PKL)
+    nodes = load_opt(NODES_PKL, {})
+    edges = load_opt(EDGES_PKL, {})
+    inverted = load_opt(INVERTED_PKL, {})
 
     # Normalize chunks container:
     # Supported:
@@ -224,6 +247,15 @@ def load_kb() -> dict[str, Any]:
     else:
         embedding_model = None
 
+    # Build embeddings_by_id from FAISS vectors — needed for incremental watch updates
+    embeddings_by_id: dict[str, np.ndarray] = {}
+    if faiss_idx is not None:
+        for i, cid in enumerate(faiss_chunk_ids):
+            try:
+                embeddings_by_id[str(cid)] = faiss_idx.reconstruct(i)
+            except Exception:
+                pass
+
     return {
         "chunks": chunks_by_id,
         "nodes": nodes_by_id,
@@ -233,6 +265,7 @@ def load_kb() -> dict[str, Any]:
         "inverted": inverted_index,
         "faiss_index": faiss_idx,
         "faiss_chunk_ids": faiss_chunk_ids,
+        "embeddings_by_id": embeddings_by_id,
         "bm25": bm25,
         "embedding_model": embedding_model,
         "meta_idx": load_one(METADATA_INDEX_PKL) if METADATA_INDEX_PKL.exists() else {},
@@ -329,9 +362,13 @@ def _kb_mtimes() -> dict[str, float | None]:
 @mcp.tool()
 def kb_status() -> dict:
     """Return detailed status about loaded KB artifacts."""
+    kb = load_kb()
     return {
         "data_dir": str(DATA_DIR),
-        "cache_info": load_kb.cache_info()._asdict(),
+        "kb_loaded": _kb is not None,
+        "watch_dir": str(_watch_dir) if _watch_dir else None,
+        "chunks": len(kb.get("chunks", {})),
+        "nodes": len(kb.get("nodes", {})),
         "files": {
             "chunks": {
                 "path": str(CHUNKS_PKL),
@@ -377,11 +414,13 @@ def kb_status() -> dict:
 def reload_kb() -> dict:
     """
     Force reload of KB artifacts from disk.
-    Useful after regenerating PKL files.
+    Useful after regenerating PKL files outside of watch mode.
     """
+    global _kb
     before = _kb_mtimes()
-    load_kb.cache_clear()
-    kb = load_kb()
+    with _kb_lock:
+        _kb = _load_kb_from_disk()
+        kb = _kb
     after = _kb_mtimes()
 
     return {
@@ -394,6 +433,139 @@ def reload_kb() -> dict:
         "mtimes_after": after,
     }
 
+
+# ── in-process watch (--watch-dir) ──────────────────────────────────────────
+
+def _watch_process_file(file_path: str) -> list:
+    """Route a changed file to the correct make_source processor."""
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).parent.parent))
+    import make_source as _ms  # noqa: PLC0415
+
+    if file_path.endswith('.md'):
+        return _ms.process_md_file(file_path)
+    if file_path.endswith(('.yaml', '.yml')):
+        base = os.path.splitext(file_path)[0]
+        if os.path.exists(base + '.go') or _ms._is_go_meta_yaml(file_path):
+            return _ms.process_go_yaml(file_path)
+        if os.path.exists(base + '.py') or _ms._is_py_meta_yaml(file_path):
+            return _ms.process_py_yaml(file_path)
+        if os.path.exists(base + '.md'):
+            return []
+        return _ms.process_yaml_file(file_path)
+    return []
+
+
+def _incremental_update_kb(changed: list, deleted: list) -> dict:
+    """Apply file changes to the in-memory KB. Must be called under _kb_lock."""
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).parent.parent))
+    import make_source as _ms  # noqa: PLC0415
+
+    kb = _kb
+    if kb is None:
+        return {'removed': 0, 'added': 0, 'total': 0}
+
+    # Remove stale chunks (changed files will be re-added below)
+    fp_set = set(changed + deleted)
+    stale_ids = {
+        cid for cid, c in kb['chunks'].items()
+        if fp_set & set(c.get('file_paths', [c.get('file_path', '')]))
+    }
+    for cid in stale_ids:
+        kb['chunks'].pop(cid, None)
+        kb['embeddings_by_id'].pop(cid, None)
+
+    # Reprocess changed files
+    new_chunks: list = []
+    for fp in changed:
+        try:
+            new_chunks.extend(_watch_process_file(fp))
+        except Exception as exc:
+            print(f"[watch] warn {os.path.basename(fp)}: {exc}", flush=True)
+
+    # Assign IDs continuing from current max
+    nums = [int(c[1:]) for c in kb['chunks'] if c.startswith('c') and c[1:].isdigit()]
+    next_id = max(nums, default=0) + 1
+    for i, chunk in enumerate(new_chunks):
+        chunk['id'] = f'c{next_id + i}'
+        chunk.setdefault('file_paths', [chunk.get('file_path', '')])
+
+    # Embed only new chunks — model already loaded
+    model = kb.get('embedding_model')
+    if new_chunks and model:
+        texts = [c.get('text', '') for c in new_chunks]
+        vecs = model.encode(texts, normalize_embeddings=True, batch_size=32, show_progress_bar=False)
+        for chunk, vec in zip(new_chunks, vecs):
+            kb['chunks'][chunk['id']] = chunk
+            kb['embeddings_by_id'][chunk['id']] = vec.astype('float32')
+
+    # Rebuild FAISS from all current embeddings (no re-encoding)
+    emb = kb['embeddings_by_id']
+    if emb:
+        id_order = list(emb.keys())
+        mat = np.stack([emb[cid] for cid in id_order]).astype('float32')
+        new_idx = faiss.IndexFlatIP(mat.shape[1])
+        new_idx.add(mat)
+        kb['faiss_index'] = new_idx
+        kb['faiss_chunk_ids'] = id_order
+
+    # Rebuild BM25 + inverted index from all current chunks (fast — no encoding)
+    all_chunks = list(kb['chunks'].values())
+    if all_chunks:
+        bm25 = _ms.build_bm25_index(all_chunks)
+        kb['inverted'] = _ms.create_bm25_inverted_index(all_chunks, bm25)
+        kb['bm25'] = bm25
+
+    return {'removed': len(stale_ids), 'added': len(new_chunks), 'total': len(kb['chunks'])}
+
+
+def _file_hash(path: str) -> str:
+    try:
+        with open(path, 'rb') as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        return ''
+
+
+def _scan_watch_dir(watch_dir: Path) -> dict:
+    result = {}
+    for root, _, files in os.walk(watch_dir):
+        for fname in files:
+            if any(fname.endswith(e) for e in ('.md', '.yaml', '.yml')) and not fname.startswith('.'):
+                p = os.path.join(root, fname)
+                result[p] = _file_hash(p)
+    return result
+
+
+def _watch_loop() -> None:
+    """Background daemon thread: polls watch_dir, applies incremental updates."""
+    state_path = DATA_DIR.parent / '.file_state.json'
+    try:
+        file_state: dict = json.loads(state_path.read_text()) if state_path.exists() else {}
+    except Exception:
+        file_state = {}
+
+    print(f"[watch] watching {_watch_dir}  interval={_watch_interval}s", flush=True)
+    while True:
+        time.sleep(_watch_interval)
+        try:
+            current = _scan_watch_dir(_watch_dir)
+            changed = [p for p, h in current.items() if file_state.get(p) != h]
+            deleted = [p for p in file_state if p not in current]
+            if changed or deleted:
+                ts = time.strftime('%H:%M:%S')
+                print(f"[watch {ts}] {len(changed)} changed, {len(deleted)} deleted", flush=True)
+                with _kb_lock:
+                    s = _incremental_update_kb(changed, deleted)
+                file_state = current
+                state_path.write_text(json.dumps(file_state, indent=2))
+                print(f"[watch] removed={s['removed']} added={s['added']} total={s['total']}", flush=True)
+        except Exception as exc:
+            print(f"[watch] error: {exc}", flush=True)
+
+
+# ── MCP tools ────────────────────────────────────────────────────────────────
 
 @mcp.tool()
 def list_edge_types() -> list[str]:
@@ -1642,11 +1814,26 @@ DEFAULT_PORT = int(os.environ.get("MCP_PORT", "8000"))
 
 
 def main() -> None:
+    global _watch_dir, _watch_interval
+
     parser = argparse.ArgumentParser(description="CIC Graph MCP Server")
     parser.add_argument("--sse", action="store_true", help="Run as SSE server")
     parser.add_argument("--host", default=DEFAULT_HOST, help=f"SSE bind host (default: {DEFAULT_HOST}, env: MCP_HOST)")
     parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"SSE bind port (default: {DEFAULT_PORT}, env: MCP_PORT)")
+    parser.add_argument("--watch-dir", metavar="DIR",
+                        default=os.environ.get("KB_WATCH_DIR"),
+                        help="Watch this directory for file changes and update KB in-memory (env: KB_WATCH_DIR)")
+    parser.add_argument("--watch-interval", type=float, default=float(os.environ.get("KB_WATCH_INTERVAL", "2")),
+                        help="Poll interval for --watch-dir in seconds (default: 2, env: KB_WATCH_INTERVAL)")
     args = parser.parse_args()
+
+    if args.watch_dir:
+        _watch_dir = Path(args.watch_dir).resolve()
+        _watch_interval = args.watch_interval
+        # Pre-load KB before starting watcher so the model is already in memory
+        load_kb()
+        t = threading.Thread(target=_watch_loop, daemon=True, name="kb-watcher")
+        t.start()
 
     if args.sse:
         print(f"Starting SSE server on http://{args.host}:{args.port}")


### PR DESCRIPTION
## Summary

- Adds `--watch-dir <DIR>` CLI option (also `KB_WATCH_DIR` env var) to the MCP server
- Background daemon thread watches the directory, detects changes by content hash
- File changes applied **in-memory** — no PKL I/O on each delta:
  - Only new/changed chunks are re-processed and re-embedded
  - Old embeddings reconstructed from FAISS at startup → stored in `embeddings_by_id` dict
  - FAISS rebuilt from embedding dict after each delta (matrix rebuild, no re-encoding)
  - BM25 + inverted index rebuilt from all chunks (tokenization only, fast)
- `_kb` / `_kb_lock` (RLock) replace `@lru_cache` for thread-safe in-place mutation
- `reload_kb()` MCP tool still works: forces full disk reload
- `graph_nodes.pkl` / `graph_edges.pkl` now optional (empty default, no crash)
- `kb_status()` returns `watch_dir`, `kb_loaded`, live chunk/node counts

## Usage

```bash
# watch source/ while serving
python mcp-server/server.py --watch-dir source/ --watch-interval 2

# or via env
KB_WATCH_DIR=source/ KB_WATCH_INTERVAL=2 python mcp-server/server.py
```

## Test plan

- [x] Syntax OK
- [x] Module import: `_kb=None`, `_kb_lock`, `_watch_dir=None`, all functions present
- [x] `load_kb()`: loads 359 chunks, `embeddings_by_id=359`, `faiss.ntotal=359`
- [x] `_incremental_update_kb()`: 1-file change → `removed=9 added=9 total=359`
- [x] Consistency: `chunks == embeddings_by_id == faiss.ntotal` after update
- [x] Missing `graph_nodes.pkl` / `graph_edges.pkl` → empty dict, no crash