### PR TITLE
feat(kb): calls graph, implements edges, Python call graph, interface tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,13 @@
 /*/*/__pycache__/
 /*/__pycache__/
 /.coverage
+
+# MCP config (generated, contains absolute paths)
+/.mcp.json
+
+# Generated knowledge base files
+/kb_data/pkl/
+/kb_data/json/
+/kb_data/manifest.json
+/sqlite_data/*.sqlite
+/sqlite_data/*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,10 @@
 # MCP config (generated, contains absolute paths)
 /.mcp.json
 
+# Generated repo-topology artifact (see knowledge.sources.yaml / project.yaml knowledge: block)
+/.gitmodules
+
 # Generated knowledge base files
-/kb_data/pkl/
-/kb_data/json/
-/kb_data/manifest.json
+/kb_data/
 /sqlite_data/*.sqlite
 /sqlite_data/*.sqlite3

--- a/.mcp.json.tpl
+++ b/.mcp.json.tpl
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "cic-graph": {
+      "command": "{{REPO_ROOT}}/p_venv/bin/python",
+      "args": [
+        "{{REPO_ROOT}}/mcp-server/server.py"
+      ],
+      "env": {
+        "KB_DATA_DIR": "{{REPO_ROOT}}/kb_data/pkl"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md — CentralInfraCore MCP Base
+
+## Mi ez a repo?
+
+Ez a **CentralInfraCore MCP base template** — egy alap Git repo amit git remote merge-vel raknak rá más CIC-ből származó repokra. Nem önálló termék, hanem template: a belőle levont repok öröklik az MCP szerver infrastruktúráját, a build tooling-ot és a release folyamatot.
+
+## MCP szerver
+
+A repo egy FastMCP-alapú knowledge base szervert tartalmaz, ami a `source/` könyvtár tartalmából épít kereshető tudásgráfot.
+
+```
+source/          ← ide kerülnek a repo docs + a CIC ökoszisztéma repo-k
+    ↓
+make kb.build    ← make_source.py: TF-IDF + cosine similarity gráf
+    ↓
+kb_data/pkl/     ← generált pickle fájlok (gitignore-d)
+    ↓
+make mcp.run     ← mcp-server/server.py (FastMCP, stdio)
+```
+
+## Kulcs parancsok
+
+```bash
+make mcp.config     # .mcp.json generálás (első lépés, repo clone után!)
+make kb.build       # Knowledge base generálás a source/ tartalmából
+make mcp.run        # MCP szerver indítás (stdio, Claude Code-hoz)
+make mcp.run.sse    # MCP szerver indítás (SSE/HTTP)
+
+make up             # Docker dev környezet (release tooling-hoz)
+make validate       # Schema validáció
+make release-check VERSION=x.y.z
+make release-prepare VERSION=x.y.z
+make release-close VERSION=x.y.z
+```
+
+## Könyvtár struktúra
+
+```
+make_source.py        ← KB generátor
+mcp-server/server.py  ← FastMCP szerver (12 tool)
+source/               ← forrás docs (gitkeep, a fogadó repo tölti fel)
+kb_data/              ← generált KB (pkl/, json/ — gitignore-d)
+sqlite_data/          ← generált SQLite (gitignore-d)
+schemas.json          ← adat struktúra sémák
+sqlite_data/db_schema.json ← SQLite tábla definíciók
+.mcp.json             ← MCP szerver konfiguráció Claude Code-hoz
+p_venv/               ← Python venv (gitignore-d)
+
+tools/                ← release tooling (compiler.py, infra.py, vault signing)
+docs/                 ← architektúra és koncept dokumentáció (EN + HU)
+features/             ← feature specifikációk
+mk/infra.mk           ← Makefile implementáció
+```
+
+## Python környezet
+
+Az MCP szerver és a KB generátor a lokális `p_venv/`-et használja (nem Docker):
+```bash
+p_venv/bin/python make_source.py
+p_venv/bin/python mcp-server/server.py
+```
+
+A release tooling (validate, test, fmt) Docker containerben fut.
+
+## MCP szerver tool-ok
+
+| Tool | Leírás |
+|------|--------|
+| `search_query` | Multi-token keresés TF-IDF invertált indexen |
+| `search_token` | Single token lookup |
+| `search_code` | Substring keresés chunk tartalomban |
+| `search_nodes` | Node keresés név/label/tag alapján |
+| `resolve_path` | Chunk keresés fájlút alapján |
+| `get_chunk` | Chunk lekérés ID alapján |
+| `get_node` | Node lekérés ID alapján |
+| `neighbors` | Graph szomszédok lekérése |
+| `focus_pack` | Kontextus csomag (rule prioritizálással) |
+| `explain_node` | Node mély elemzése |
+| `kb_status` | KB állapot és fájl info |
+| `reload_kb` | KB újratöltés lemezről |
+
+## Repo konvenciók
+
+- Branch naming: `{component}/releases/v{VERSION}` (release), `mcp/devel` (MCP fejlesztés)
+- Tag format: `{component}@v{VERSION}`
+- Commit signing: Vault Transit engine (git hook)
+- `project.yaml`: minden release metaadatot és kriptográfiai aláírást tartalmaz
+- `md.meta.schema.yaml`: dokumentáció metadata sémája (tags, categories, used_in)
+
+## Kapcsolódó rendszerek
+
+- **CIC-Relay**: Go-alapú control plane (Nexus orchestrator, WASM)
+- **CIC-Schemas**: Schema compiler és Vault signing
+- **CIC-Registry**: 3-rétegű registry (schemas/mods/agents)
+- **HashiCorp Vault**: Transit signing, KV v2 cert storage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,98 @@ A release tooling (validate, test, fmt) Docker containerben fut.
 | `kb_status` | KB állapot és fájl info |
 | `reload_kb` | KB újratöltés lemezről |
 
+## AI Reasoning Protocol
+
+### Boot fázis (kötelező session-indításkor)
+
+Mielőtt szakmai kérdésre válaszolsz, futtasd le ezt a szekvenciát:
+
+1. `kb_status` — KB artifact állapot ellenőrzése
+2. Keress rá az `axioms` és `symbols` node-okra (`search_nodes`)
+3. Keress rá a `limits` és `contract` fogalmakra
+4. Határozd meg a runtime státuszt: **production / scaffold / concept**
+
+A boot végén internalizáld:
+- Mit tekintesz invariánsnak
+- Melyek a kulcsfogalmak
+- Mi runtime, mi scaffold, mi csak koncepció
+
+**Amíg ez nem teljesült, ne válaszolj szakmai kérdésre.**
+
+### Graph-first reasoning (ne search→snippet→answer)
+
+Query helyett subgraph-építés:
+
+1. Azonosítsd a fogalmat
+2. Keresd meg az induló node-okat (`search_nodes`, `find_nodes`)
+3. Járd be az 1–2 hop szomszédokat (`neighbors`)
+4. Szűrj kapcsolattípus szerint
+5. Építs lokális subgraphot
+6. Csak ebből válaszolj
+
+A chunk nem elsődleges tudáselem — csak bizonyíték. Elsődleges: **node, edge, status, provenance**.
+
+### Háromrétegű státusz-kényszer
+
+Minden állítás előtt kötelező meghatározni:
+
+- `implemented` — van kód, van runtime belépési pont
+- `scaffold` — van kód, de nincs éles runtime híd
+- `concept` — csak dokumentáció vagy graph node, kód nincs
+
+Ha node- vagy file-szinten nem tudod alátámasztani, **nem mondhatod ki tényként**.
+
+### Kötelező ellenőrző lánc
+
+Minden fontos állításhoz belső validáció:
+
+```
+fogalom → definíciós doc → companion/meta → graph kapcsolat → kód/scaffold hely → runtime belépési pont
+```
+
+Ha a lánc megszakad:
+> "a modell itt létezik, de az implementációs lánc itt megszakad: [hely]"
+
+Nem azt mondod, hogy "nincs" — hanem megnevezed, hol törik el.
+
+### Bridge detector
+
+Minden válasz előtt ellenőrizd a hidakat:
+
+- `concept → code` bridge: van-e implementáció?
+- `code → runtime` bridge: van-e belépési pont?
+- `runtime → audit` bridge: van-e trace/log/proof?
+
+Ha hiányzik: státusz = scaffold vagy concept, nem implemented.
+
+### Immersion mód
+
+Ha a feladat fogalmi megértés (nem implementáció, nem audit):
+
+**Tilos:**
+- Javaslatot tenni
+- Kritikát mondani
+- Hiányt feltételezni
+
+**Csak:**
+- Axiómákat felvenni
+- Fogalmi szerkezetet és relációkat térképezni
+- Rendszerlogikát internalizálni
+
+### Válasz formátum (strukturált állításokhoz)
+
+| Mező | Tartalom |
+|------|----------|
+| **fogalom** | mi ez |
+| **mit jelent a rendszerben** | szerepe, funkciója |
+| **hol él** | node ID, fájlút |
+| **státusz** | implemented / scaffold / concept |
+| **mihez kapcsolódik** | szomszédos node-ok, edge-típusok |
+| **bizonyíték** | chunk ID vagy doc referencia |
+| **nyitott híd** | hol törik el az implementációs lánc |
+
+---
+
 ## Repo konvenciók
 
 - Branch naming: `{component}/releases/v{VERSION}` (release), `mcp/devel` (MCP fejlesztés)

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,24 @@
 include mk/infra.mk
 
 # ---- Phony ----
-.PHONY: all help validate release test up down shell build fmt lint check typecheck repo.init manifest-verify manifest-update
+.PHONY: all help validate release-check release-prepare release-close test up down shell build fmt lint check typecheck repo.init manifest-verify manifest-update
 
 # Default to showing help
 all: help
 
 # =============================================================================
-# Compiler Flags (can be overridden on command line, e.g., make release VERBOSE=1)
+# Compiler Flags (can be overridden on command line)
 # =============================================================================
 VERBOSE ?=
 DEBUG ?=
 DRY_RUN ?=
-VERSION ?= # New: Version for release command
+VERSION ?=
 GIT_TIMEOUT ?= 60
 VAULT_TIMEOUT ?= 10
-TEST_FILE ?= # New: Specify a specific test file (e.g., tests/test_compiler.py)
-TEST_NAME ?= # New: Specify a specific test function name (e.g., test_load_yaml_valid)
+TEST_FILE ?=
+TEST_NAME ?=
 
-# Construct COMPILER_CLI_ARGS based on VERBOSE and DEBUG flags
+# Construct COMPILER_CLI_ARGS based on flags
 COMPILER_CLI_ARGS =
 ifeq ($(VERBOSE),1)
     COMPILER_CLI_ARGS += --verbose
@@ -66,21 +66,36 @@ validate:
 	@echo "--- Validating all schemas against the meta-schema ---"
 	@docker compose exec builder python -m tools.compiler validate $(COMPILER_CLI_ARGS)
 
-release:
+release-check:
 ifeq ($(VERSION),)
-	$(error VERSION is required for the release command. Usage: make release VERSION=1.0.0)
+	$(error VERSION is required. Usage: make release-check VERSION=1.0.0)
 endif
-	@echo "--- Building and signing release schemas ---"
-	# Pass Git author and committer identity from host to container for commit operations
+	@echo "--- Running pre-flight checks for release v$(VERSION) ---"
+	@docker compose exec builder python -m tools.compiler check --version $(VERSION) $(COMPILER_CLI_ARGS)
+
+release-prepare:
+ifeq ($(VERSION),)
+	$(error VERSION is required. Usage: make release-prepare VERSION=1.0.0)
+endif
+	@echo "--- Preparing release v$(VERSION) ---"
 	@docker compose exec \
 		-e GIT_AUTHOR_NAME="$(shell git config user.name)" \
 		-e GIT_AUTHOR_EMAIL="$(shell git config user.email)" \
 		-e GIT_COMMITTER_NAME="$(shell git config user.name)" \
 		-e GIT_COMMITTER_EMAIL="$(shell git config user.email)" \
-		builder python -m tools.compiler release --version $(VERSION) $(COMPILER_CLI_ARGS)
-	# The release.sh script is no longer needed as its functionality has been integrated into compiler.py
-	# @tools/release.sh project.yaml
-	# @git add project.yaml # This is now handled by compiler.py
+		builder python -m tools.compiler prepare --version $(VERSION) $(COMPILER_CLI_ARGS)
+
+release-close:
+ifeq ($(VERSION),)
+	$(error VERSION is required. Usage: make release-close VERSION=1.0.0)
+endif
+	@echo "--- Finalizing and closing release v$(VERSION) ---"
+	@docker compose exec \
+		-e GIT_AUTHOR_NAME="$(shell git config user.name)" \
+		-e GIT_AUTHOR_EMAIL="$(shell git config user.email)" \
+		-e GIT_COMMITTER_NAME="$(shell git config user.name)" \
+		-e GIT_COMMITTER_EMAIL="$(shell git config user.email)" \
+		builder python -m tools.compiler close --version $(VERSION) $(COMPILER_CLI_ARGS)
 
 test: infra.test
 
@@ -129,18 +144,22 @@ help:
 	@echo ""
 	@echo "Main Tasks:"
 	@echo "  validate      Run fast, offline validation of all schemas."
-	@echo "  release       Build, checksum, and sign all non-dev schemas (requires Vault)."
 	@echo "  test          Run pytest for the compiler infrastructure code."
+	@echo ""
+	@echo "Release Process (multi-step):"
+	@echo "  release-check    Run pre-flight checks before starting a release."
+	@echo "  release-prepare  Step 1: Create release branch and prepare project.yaml."
+	@echo "  release-close    Step 2: Finalize, tag, merge, and clean up the release."
 	@echo ""
 	@echo "Manifest Management:"
 	@echo "  manifest-verify  Verify the integrity of the repository using MANIFEST.sha256."
 	@echo "  manifest-update  Re-generate the MANIFEST.sha256 file."
 	@echo ""
-	@echo "Options for validate/release:"
+	@echo "Options for validate/release-*:"
 	@echo "  VERBOSE=1     Enable verbose output."
 	@echo "  DEBUG=1       Enable debug output (most verbose)."
 	@echo "  DRY_RUN=1     Perform a trial run without making any changes."
-	@echo "  VERSION=X.Y.Z The semantic version to release (e.g., 1.0.0). Required for 'release' command."
+	@echo "  VERSION=X.Y.Z The semantic version to release (e.g., 1.0.0). Required for all 'release-*' commands."
 	@echo "  GIT_TIMEOUT=N Set Git command timeout in seconds (default: 60)."
 	@echo "  VAULT_TIMEOUT=N Set Vault API call timeout in seconds (default: 10)."
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 include mk/infra.mk
 
 # ---- Phony ----
-.PHONY: all help validate release-check release-prepare release-close test up down shell build fmt lint check typecheck repo.init manifest-verify manifest-update
+.PHONY: all help validate release-check release-prepare release-close test up down shell build fmt lint check typecheck repo.init manifest-verify manifest-update kb.build mcp.run mcp.run.sse mcp.config
 
 # Default to showing help
 all: help
@@ -129,6 +129,15 @@ check: infra.check
 repo.init: infra.repo.init
 
 # =============================================================================
+# Knowledge Base & MCP Server (p_venv based, no Docker)
+# =============================================================================
+
+kb.build: infra.kb.build
+mcp.run: infra.mcp.run
+mcp.run.sse: infra.mcp.run.sse
+mcp.config: infra.mcp.config
+
+# =============================================================================
 # Help
 # =============================================================================
 
@@ -175,6 +184,12 @@ help:
 	@echo ""
 	@echo "Repository Setup:"
 	@echo "  repo.init     Set up the Git hooks for this repository."
+	@echo ""
+	@echo "Knowledge Base & MCP Server:"
+	@echo "  mcp.config    Generate .mcp.json with correct paths for this repo."
+	@echo "  kb.build      Build the knowledge base from ./source."
+	@echo "  mcp.run       Start the MCP server (stdio)."
+	@echo "  mcp.run.sse   Start the MCP server (SSE/HTTP)."
 	@echo ""
 	@echo "Maintenance:"
 	@echo "  infra.deps    (Re)generate and install dependencies."

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 include mk/infra.mk
 
 # ---- Phony ----
-.PHONY: all help validate release-check release-prepare release-close test up down shell build fmt lint check typecheck repo.init manifest-verify manifest-update kb.build mcp.run mcp.run.sse mcp.config
+.PHONY: all help validate release-check release-prepare release-close test up down shell build fmt lint check typecheck repo.init manifest-verify manifest-update kb.gitmodules kb.gitmodules.check kb.build mcp.run mcp.run.sse mcp.config
 
 # Default to showing help
 all: help
@@ -132,6 +132,8 @@ repo.init: infra.repo.init
 # Knowledge Base & MCP Server (p_venv based, no Docker)
 # =============================================================================
 
+kb.gitmodules: infra.kb.gitmodules
+kb.gitmodules.check: infra.kb.gitmodules.check
 kb.build: infra.kb.build
 mcp.run: infra.mcp.run
 mcp.run.sse: infra.mcp.run.sse

--- a/ai/profiles/scope/cabinet.yaml
+++ b/ai/profiles/scope/cabinet.yaml
@@ -1,0 +1,34 @@
+---
+scope: cabinet
+version: "1.0"
+repo: CIC-Relay
+description: >
+  WASM executor, workflow graph, ProofTrace, schema validation.
+  The central execution engine of CIC-Relay.
+
+owns:
+  - core/cabinet/
+
+reads:
+  - pkg/obs/
+  - pkg/wasm/
+  - core/nexus/recorder/
+
+test_cmd: go test ./core/cabinet/...
+coverage_min: 85
+
+key_interfaces:
+  - Cabinet (core/cabinet/interface.go)
+  - ExecutionGraph (core/cabinet/graph.go)
+  - ProofTrace (core/cabinet/proof_trace.go)
+
+mcp_focus_queries:
+  - "cabinet workflow execution"
+  - "ProofTrace chain hash"
+  - "WASM module executor"
+  - "schema validation cabinet"
+
+invariants:
+  - ProofTrace.ChainHash is deterministic given the same step sequence
+  - ExecutionGraph step format: "component@version.function(inputKey) -> outputKey"
+  - SetResponse always includes ProofTrace on success

--- a/ai/profiles/scope/crypto.yaml
+++ b/ai/profiles/scope/crypto.yaml
@@ -1,0 +1,28 @@
+---
+scope: crypto
+version: "1.0"
+repo: CIC-Relay
+description: >
+  Vault Transit signing service. The cryptographic trust anchor for all
+  CIC-Relay artifacts. Invariants are absolute — no exceptions.
+
+owns:
+  - core/nexus/crypto/
+
+reads:
+  - pkg/obs/
+
+test_cmd: go test ./core/nexus/crypto/...
+coverage_min: 80
+
+mcp_focus_queries:
+  - "Vault Transit signing crypto"
+  - "ECDSA SHA256 prehashed"
+  - "CICDeveloperCA signing"
+
+invariants:
+  - prehashed: true must always be set in Vault Transit calls — never change
+  - hash_algorithm must always be sha2-256 — never change
+  - Signing format [signing-metadata]+[certificate] blocks are invariant
+  - Secrets (token, cert, PAT) always from env or bind mount — never hardcoded
+  - Key rotation: only via Vault policy, not in code

--- a/ai/profiles/scope/iac.yaml
+++ b/ai/profiles/scope/iac.yaml
@@ -1,0 +1,35 @@
+---
+scope: iac
+version: "1.0"
+repo: CIC-Relay
+description: >
+  IaC source loader: file, git, and upstream HTTP sources for configuration.
+  Relay federation v2 entry point (UpstreamSource scaffold → implemented).
+
+owns:
+  - core/nexus/iac/
+
+reads:
+  - core/nexus/git/
+  - pkg/obs/
+
+test_cmd: go test ./core/nexus/iac/...
+coverage_min: 80
+
+key_interfaces:
+  - IaCSource (loader.go)
+  - FileSource (source_file.go)
+  - GitSource (source_git.go)
+  - UpstreamSource (source_upstream.go) — scaffold, Sprint 15 task
+
+active_tasks:
+  - upstream-source-http: implement UpstreamSource HTTP fetch + retry/backoff
+
+mcp_focus_queries:
+  - "IaC source loader upstream"
+  - "UpstreamSource HTTP CIC_UPSTREAM_URL"
+  - "federation relay config"
+
+invariants:
+  - All IaCSource implementations must be deterministic given the same env
+  - CIC_UPSTREAM_URL controls upstream endpoint — no hardcoded URLs

--- a/ai/profiles/scope/isolation.yaml
+++ b/ai/profiles/scope/isolation.yaml
@@ -1,0 +1,26 @@
+---
+scope: isolation
+version: "1.0"
+repo: CIC-Relay
+description: >
+  WASM sandbox isolation coordinator. Controls resource limits, capability
+  grants, and execution boundaries for untrusted modules.
+
+owns:
+  - core/nexus/isolation/
+
+reads:
+  - core/cabinet/
+  - pkg/obs/
+
+test_cmd: go test ./core/nexus/isolation/...
+coverage_min: 75
+
+mcp_focus_queries:
+  - "isolation WASM sandbox coordinator"
+  - "capability grant resource limit"
+  - "untrusted module execution boundary"
+
+invariants:
+  - isolation must never grant capabilities not in the module's signed manifest
+  - Resource limits are always enforced before execution — never after

--- a/ai/profiles/scope/obs.yaml
+++ b/ai/profiles/scope/obs.yaml
@@ -1,0 +1,30 @@
+---
+scope: obs
+version: "1.0"
+repo: CIC-Relay
+description: >
+  Observability layer: structured logging sinks, capture chains, registry.
+  Used by all other scopes for audit and diagnostic output.
+
+owns:
+  - pkg/obs/
+
+reads:
+  - (all scopes import obs — no reverse reads needed)
+
+test_cmd: go test ./pkg/obs/...
+coverage_min: 75
+
+key_interfaces:
+  - Sink (pkg/obs/sink.go)
+  - Registry (pkg/obs/registry.go)
+  - CaptureChain (pkg/obs/chain.go)
+
+mcp_focus_queries:
+  - "obs sink logging"
+  - "capture chain observability"
+  - "logrus sink registry"
+
+invariants:
+  - obs must not import from core/ (avoids circular deps)
+  - Sink.Write is always non-blocking (caller never blocks on log)

--- a/ai/profiles/scope/operator.yaml
+++ b/ai/profiles/scope/operator.yaml
@@ -1,0 +1,30 @@
+---
+scope: operator
+version: "1.0"
+repo: CIC-Relay
+description: >
+  Operator orchestration: coordinates nexus sub-systems, builds the runtime
+  execution context. Nexus top-level coordinator.
+
+owns:
+  - core/nexus/operator/
+
+reads:
+  - core/nexus/recorder/
+  - core/nexus/iac/
+  - core/nexus/crypto/
+  - core/nexus/isolation/
+  - core/nexus/git/
+  - pkg/obs/
+
+test_cmd: go test ./core/nexus/operator/...
+coverage_min: 75
+
+mcp_focus_queries:
+  - "operator nexus coordinator"
+  - "buildOperatorIfConfigured"
+  - "nexus runtime context"
+
+invariants:
+  - operator must not import cabinet (one-way dependency)
+  - buildOperatorIfConfigured error must be a hard failure (no silencing)

--- a/ai/profiles/scope/recorder.yaml
+++ b/ai/profiles/scope/recorder.yaml
@@ -1,0 +1,30 @@
+---
+scope: recorder
+version: "1.0"
+repo: CIC-Relay
+description: >
+  State recorder: persists expected vs actual state with Vault Transit signing.
+  Part of the ProofTrace audit trail.
+
+owns:
+  - core/nexus/recorder/
+
+reads:
+  - core/cabinet/proof_trace.go
+  - core/nexus/crypto/
+
+test_cmd: go test ./core/nexus/recorder/...
+coverage_min: 80
+
+key_interfaces:
+  - Recorder (core/nexus/recorder/)
+  - RecordedState
+
+mcp_focus_queries:
+  - "recorder state expected actual"
+  - "Vault Transit signing recorder"
+  - "ProofTrace audit"
+
+invariants:
+  - Vault signing failure is WARN, not fatal (does not abort workflow)
+  - expected_state = workflow input, actual_state = ProofTrace output

--- a/ai/profiles/task/auditor.yaml
+++ b/ai/profiles/task/auditor.yaml
@@ -1,0 +1,42 @@
+---
+profile: auditor
+version: "1.0"
+description: >
+  Read-only audit of a scope for correctness, security, and contract compliance.
+  Produces a structured findings report. No code changes.
+
+boot_sequence:
+  - kb_status
+  - focus_pack(scope_query)
+  - read CONTRACT.md and LIMITS.md
+  - read LLM_RULES.md if present
+
+allowed:
+  - read all files in scope (source, tests, YAML, docs)
+  - call all MCP read-only tools
+  - record findings via record_decision
+
+forbidden:
+  - modify any file
+  - run make targets that modify state
+  - git add / commit / push
+
+output:
+  - type: audit_report
+    description: |
+      Structured list of findings per file:
+        - file, finding_type (bug/security/contract/style), severity, description, suggested_fix
+    commit_required: false
+
+accept:
+  - report covers all files in scope
+  - each finding references a specific line or node_id
+  - P0 findings call out security or data integrity issues explicitly
+
+mcp_tools_required:
+  - kb_status
+  - focus_pack
+  - impact_analysis
+  - neighbors
+  - explain_node
+  - record_decision

--- a/ai/profiles/task/companion.yaml
+++ b/ai/profiles/task/companion.yaml
@@ -1,0 +1,42 @@
+---
+profile: companion
+version: "1.0"
+description: >
+  Fill semantic fields in companion YAMLs for a scope. Uses go.meta.gen.py --merge
+  and update_companion MCP tool. The primary KB enrichment agent.
+
+boot_sequence:
+  - kb_status
+  - missing_companions(source_dir=scope_root)
+  - focus_pack(scope_query)
+  - read go.meta.schema.yaml for allowed field values
+
+allowed:
+  - read Go source files (no modification)
+  - run go.meta.gen.py --merge on specific files
+  - call update_companion via MCP
+  - write companion .yaml files
+
+forbidden:
+  - modify .go source files
+  - modify auto-generated fields (package, objects[].references)
+  - add invented information not derivable from the source code
+  - git push
+
+output:
+  - type: companion_yaml
+    description: Companion YAMLs with category, used_in, related_nodes, description filled
+    commit_required: true
+
+accept:
+  - missing_companions() returns 0 incomplete for the scope
+  - go.meta.gen.py --dry-run reports 0 errors
+  - no Go source files modified
+
+mcp_tools_required:
+  - kb_status
+  - missing_companions
+  - update_companion
+  - focus_pack
+  - neighbors
+  - explain_node

--- a/ai/profiles/task/explore.yaml
+++ b/ai/profiles/task/explore.yaml
@@ -1,0 +1,44 @@
+---
+profile: explore
+version: "1.0"
+description: >
+  Read-only investigation of a component. Maps structure, identifies gaps,
+  generates companion YAMLs. No code changes.
+
+boot_sequence:
+  - kb_status
+  - focus_pack(scope_query)
+  - missing_companions(source_dir=scope_root)
+  - read CLAUDE.md in scope root
+
+allowed:
+  - read source files (Go, YAML, Markdown)
+  - call MCP read-only tools (focus_pack, impact_analysis, guided_path, neighbors, search_*)
+  - run go.meta.gen.py --merge (companion update only)
+  - call update_companion via MCP
+
+forbidden:
+  - modify Go source files (.go)
+  - modify test files (*_test.go)
+  - modify Makefile or CI workflows
+  - delete files
+  - git push
+
+output:
+  - type: companion_yaml
+    description: Updated or created companion YAML files with semantic fields filled
+    commit_required: true
+  - type: exploration_report
+    description: Summary of findings (to be recorded via record_decision)
+
+accept:
+  - all companion YAMLs in scope have non-empty description
+  - go.meta.gen.py --merge reports 0 errors
+  - no Go files modified
+
+mcp_tools_required:
+  - kb_status
+  - focus_pack
+  - missing_companions
+  - update_companion
+  - record_decision

--- a/ai/profiles/task/implement.yaml
+++ b/ai/profiles/task/implement.yaml
@@ -1,0 +1,54 @@
+---
+profile: implement
+version: "1.0"
+description: >
+  Implement a PROMPTMAP task in a bounded scope. Reads the task prompt,
+  writes Go code, runs accept gate. May update companion YAMLs.
+
+boot_sequence:
+  - kb_status
+  - get_next_task(repo, sprint)
+  - focus_pack(task_topic)
+  - read scope CLAUDE.md
+  - read CONTRACT.md and LIMITS.md in scope
+
+allowed:
+  - read and write Go source files within scope
+  - write companion YAMLs
+  - run make test, make verify, make coverage-check-pkgs
+  - call all MCP tools
+  - claim_task, complete_task, fail_task via MCP
+
+forbidden:
+  - modify files outside declared scope (owns + reads lists)
+  - delete tests
+  - hardcode secrets (tokens, certs, PATs) — env vars only
+  - modify signing format or Vault call parameters
+  - git push
+
+output:
+  - type: go_source
+    description: Modified or created Go source files
+    commit_required: true
+  - type: companion_yaml
+    description: Updated companion YAML for modified files (via go.meta.gen.py --merge)
+    commit_required: true
+
+accept:
+  - accept field from PROMPTMAP task passes (0 exit code)
+  - no new test failures
+  - no secrets in diff
+
+trust_constraints:
+  - prehashed: true must not be changed in Vault calls
+  - signing format [signing-metadata]+[certificate] blocks are invariant
+  - Vault token/cert must come from env or bind mount
+
+mcp_tools_required:
+  - kb_status
+  - focus_pack
+  - impact_analysis
+  - claim_task
+  - complete_task
+  - fail_task
+  - update_companion

--- a/ai/profiles/task/release.yaml
+++ b/ai/profiles/task/release.yaml
@@ -1,0 +1,41 @@
+---
+profile: release
+version: "1.0"
+description: >
+  Prepare and execute a versioned release. Validates, signs artifacts,
+  updates project.yaml, creates release tag.
+
+boot_sequence:
+  - kb_status
+  - read project.yaml for current version
+  - run make release-check VERSION=target
+  - verify make validate is green
+
+allowed:
+  - read all files in scope
+  - run make release-check, make release-prepare, make release-close
+  - update project.yaml version field
+  - create annotated git tags
+  - call all MCP tools
+
+forbidden:
+  - force-push to main
+  - skip signing steps (--no-verify)
+  - hardcode version in source code (only project.yaml)
+  - modify CHANGELOG or MANIFEST manually
+
+output:
+  - type: release_tag
+    description: Annotated git tag at the release commit, Vault-signed
+    commit_required: true
+  - type: project_yaml
+    description: Updated project.yaml with new version and checksum
+
+accept:
+  - make release-check exits 0
+  - git tag exists and points to HEAD
+  - project.yaml version matches tag
+
+mcp_tools_required:
+  - kb_status
+  - focus_pack

--- a/ai/profiles/task/test-writer.yaml
+++ b/ai/profiles/task/test-writer.yaml
@@ -1,0 +1,39 @@
+---
+profile: test-writer
+version: "1.0"
+description: >
+  Write or extend tests for a specific scope to reach coverage targets.
+  Does not modify production code.
+
+boot_sequence:
+  - kb_status
+  - focus_pack(scope_query)
+  - run: go test -coverprofile=coverage.out ./scope/...
+  - identify uncovered branches from coverage report
+
+allowed:
+  - write and modify *_test.go files within scope
+  - read Go source files (no modification)
+  - run make test, make coverage-check-pkgs
+  - call MCP read-only tools
+
+forbidden:
+  - modify non-test Go source files
+  - modify Makefile, CI, signing hooks
+  - skip or remove existing tests
+  - use t.Skip() without a // reason comment
+
+output:
+  - type: test_files
+    description: New or extended *_test.go files
+    commit_required: true
+
+accept:
+  - coverage >= threshold defined in scope profile
+  - make test green (0 exit)
+  - no existing tests removed or disabled
+
+mcp_tools_required:
+  - kb_status
+  - focus_pack
+  - neighbors

--- a/go.meta.schema.yaml
+++ b/go.meta.schema.yaml
@@ -1,0 +1,156 @@
+---
+type: object
+required:
+  - package
+  - description
+  - tags
+  - category
+  - used_in
+  - entrypoint
+  - related_nodes
+  - objects
+properties:
+  package:
+    type: string
+    description: Go package name as declared in the source file.
+
+  description:
+    type: string
+    description: Human-readable summary of the file's purpose (Hungarian or English).
+
+  tags:
+    type: array
+    description: "Thematic tags for AI context integration. Allowed values:"
+    items:
+      type: string
+      enum:
+        - relay             # Related to AI relay modules
+        - compliance        # Compliance or validation logic
+        - workflow          # Process or pipeline logic
+        - cictor            # Part of the CICTOR decision system
+        - schema            # Schema processing
+        - parser            # Input parsing
+        - guard             # Access or protection logic
+        - core              # Core system logic
+        - doc               # Documentation or explanatory content
+        - interface         # Interface logic with external systems
+        - gateway           # Entry or gateway-related logic
+        - builder           # Build or generation tasks
+        - test              # Validation, testing or debugging logic
+        - meta              # Meta-structures or internal definitions
+        - orchestrator      # Coordinates control or decision chains
+        - decision          # Decision logic
+        - reflector         # Feedback or reflection module
+        - context           # Contextual management
+        - validator         # Data or schema validation
+        - executor          # Direct logic execution
+        - hook              # Event-triggered callable logic
+        - template          # Template component
+        - fallback          # Fallback or alternative behavior
+        - session           # Session or state-handling
+        - metrics           # Metric collection or monitoring
+        - storage           # Storage or persistence
+        - loader            # Config or module loading
+        - renderer          # Output generation
+        - platform-engineering
+        - ci-cd
+        - ecosystem
+
+  category:
+    type: array
+    description: "Functional role(s) of the file. Allowed values:"
+    items:
+      type: string
+      enum:
+        - modul             # General module
+        - decision          # Decision logic
+        - morális           # Moral or rule-based logic
+        - belépési          # Entry point (user or system)
+        - meta              # Internal meta structures
+        - elemző            # Evaluation or analysis logic
+        - concept           # High-level concept
+        - architecture      # Architectural blueprint
+        - ci-cd             # CI/CD related
+
+  used_in:
+    type: array
+    description: "Workflows or processes where this file is used. Allowed values:"
+    items:
+      type: string
+      enum:
+        - decision_flow         # Decision logic execution
+        - validation            # Validation process
+        - generation            # Build or generation pipeline
+        - onboarding            # System initialization
+        - fallback_process      # Fallback handling
+        - distribution          # Software distribution
+        - publishing            # Release publishing
+        - development-process   # Core development process
+        - architecture-review   # Architecture review
+
+  entrypoint:
+    type: boolean
+    description: Whether this file is a system or workflow entry point (e.g. main package, cmd/).
+
+  related_nodes:
+    type: array
+    items:
+      type: string
+    description: >
+      References to related concepts, modules, or other Go files.
+      Use relative paths (e.g. 'core/nexus/cabinet') or concept names.
+
+  objects:
+    type: array
+    description: All top-level objects defined in this Go file.
+    items:
+      type: object
+      required:
+        - name
+        - kind
+        - description
+      properties:
+        name:
+          type: string
+          description: Identifier name as declared in Go source.
+
+        kind:
+          type: string
+          description: Kind of the Go declaration.
+          enum:
+            - struct        # type Name struct { ... }
+            - interface     # type Name interface { ... }
+            - func          # func Name(...) ...
+            - method        # func (recv Type) Name(...) ...
+            - type          # type Name UnderlyingType
+            - var           # package-level var
+            - const         # package-level const
+
+        receiver:
+          type: string
+          description: >
+            Receiver type name for methods (kind: method).
+            Example: "relayServer" for func (s *relayServer) Handle(...)
+
+        description:
+          type: string
+          description: Human-readable summary of what this object does.
+
+        implements:
+          type: array
+          items:
+            type: string
+          description: >
+            Interface(s) this struct implements. Use "pkg.Interface" for
+            external interfaces, plain "Interface" for local ones.
+            Only relevant for kind: struct.
+
+        references:
+          type: array
+          items:
+            type: string
+          description: >
+            Non-stdlib types/objects referenced by this declaration.
+            Includes both third-party (e.g. "logrus.Logger") and same-module
+            cross-package references (e.g. "cabinet.Cabinet").
+            Format: "pkg.Type". Auto-generated by go.meta.gen.py — review and trim as needed.

--- a/kb_data/.gitignore
+++ b/kb_data/.gitignore
@@ -1,0 +1,4 @@
+# Generated knowledge base artifacts - do not commit
+/pkl/*.pkl
+/json/*.json
+/manifest.json

--- a/kb_data/edge_types.md
+++ b/kb_data/edge_types.md
@@ -1,0 +1,8 @@
+# Edge Types Documentation
+
+This document lists all unique edge types automatically discovered in the knowledge graph.
+
+Understanding these relationships is key to querying and interpreting the graph's structure.
+
+- `refers-to`
+- `related-to`

--- a/make_source.py
+++ b/make_source.py
@@ -313,6 +313,17 @@ def create_knowledge_graph_with_content(chunks, embeddings):
         edge['id'] = f'e{i+1}'
     return nodes, edges
 
+def _is_go_meta_yaml(file_path):
+    """Return True if the YAML file is a Go meta companion (has 'package' + 'objects').
+    Used when the sibling .go file is absent (e.g. in docs-only submodules)."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+        return isinstance(data, dict) and 'package' in data and 'objects' in data
+    except Exception:
+        return False
+
+
 def process_directory(directory_path):
     all_chunks = []
 
@@ -341,7 +352,12 @@ def process_directory(directory_path):
             elif file.endswith(('.yaml', '.yml')):
                 if file_path in go_companion_yamls:
                     all_chunks.extend(process_go_yaml(file_path))
-                elif file_path not in md_companion_yamls:
+                elif file_path in md_companion_yamls:
+                    pass  # handled by process_md_file
+                elif _is_go_meta_yaml(file_path):
+                    # Go meta YAML without sibling .go (e.g. in docs-only submodule)
+                    all_chunks.extend(process_go_yaml(file_path))
+                else:
                     all_chunks.extend(process_yaml_file(file_path))
 
     return all_chunks

--- a/make_source.py
+++ b/make_source.py
@@ -79,7 +79,7 @@ def build_faiss_index(embeddings):
 
 def build_bm25_index(chunks):
     """Build BM25 index for lexical search."""
-    tokenized = [chunk['text'].lower().split() for chunk in chunks]
+    tokenized = [chunk['text'].lower().split() or [""] for chunk in chunks]
     return BM25Okapi(tokenized)
 
 def create_bm25_inverted_index(chunks, bm25):

--- a/make_source.py
+++ b/make_source.py
@@ -21,25 +21,69 @@ def detect_language(text):
     except LangDetectException:
         return 'unknown'
 
+def load_companion_yaml(md_path):
+    """Load a companion .yaml file for an .md file if it exists."""
+    yaml_path = os.path.splitext(md_path)[0] + '.yaml'
+    if not os.path.exists(yaml_path):
+        return None
+    try:
+        with open(yaml_path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+        return data if isinstance(data, dict) else None
+    except (yaml.YAMLError, IOError):
+        return None
+
+def _normalize_list(val):
+    """Normalize a YAML value to a list of strings."""
+    if not val:
+        return []
+    if isinstance(val, list):
+        return [str(x) for x in val]
+    return [str(val)]
+
 def process_md_file(file_path):
     chunks = []
     with open(file_path, 'r', encoding='utf-8') as f:
         lines = f.readlines()
+
+    companion = load_companion_yaml(file_path)
+    meta = {}
+    if companion:
+        meta = {
+            'tags':          _normalize_list(companion.get('tags')),
+            'category':      _normalize_list(companion.get('category')),
+            'used_in':       _normalize_list(companion.get('used_in')),
+            'related_nodes': _normalize_list(companion.get('related_nodes')),
+            'entrypoint':    bool(companion.get('entrypoint', False)),
+            'description':   str(companion.get('description', '')).strip(),
+        }
+
     current_chunk_lines, current_header, start_line = [], "", 1
     for i, line in enumerate(lines):
         match = re.match(r'^(#+)\s(.*)', line)
         if match:
             if current_chunk_lines:
                 text = "".join(current_chunk_lines).strip()
-                if text: chunks.append({'text': text, 'file_path': file_path, 'section': current_header, 'start_line': start_line, 'end_line': i, 'lang': detect_language(text), 'type': 'section'})
+                if text:
+                    chunk = {'text': text, 'file_path': file_path, 'section': current_header,
+                             'start_line': start_line, 'end_line': i,
+                             'lang': detect_language(text), 'type': 'section'}
+                    chunk.update(meta)
+                    chunks.append(chunk)
             start_line = i + 1
             current_header = match.group(2).strip()
             current_chunk_lines = [line]
         else:
             current_chunk_lines.append(line)
+
     if current_chunk_lines:
         text = "".join(current_chunk_lines).strip()
-        if text: chunks.append({'text': text, 'file_path': file_path, 'section': current_header, 'start_line': start_line, 'end_line': len(lines), 'lang': detect_language(text), 'type': 'section'})
+        if text:
+            chunk = {'text': text, 'file_path': file_path, 'section': current_header,
+                     'start_line': start_line, 'end_line': len(lines),
+                     'lang': detect_language(text), 'type': 'section'}
+            chunk.update(meta)
+            chunks.append(chunk)
     return chunks
 
 def process_yaml_file(file_path):
@@ -49,7 +93,6 @@ def process_yaml_file(file_path):
             yaml_content = yaml.safe_load(file)
             if not yaml_content:
                 return []
-            # Dump the whole yaml content into a single text block
             text_content = yaml.dump(yaml_content, allow_unicode=True, default_flow_style=False, indent=2)
             return [{
                 'text': text_content,
@@ -58,7 +101,9 @@ def process_yaml_file(file_path):
                 'start_line': 1,
                 'end_line': len(text_content.splitlines()),
                 'lang': 'yaml',
-                'type': 'yaml_file'
+                'type': 'yaml_file',
+                'tags': [], 'category': [], 'used_in': [],
+                'related_nodes': [], 'entrypoint': False, 'description': '',
             }]
     except (yaml.YAMLError, IOError):
         return []
@@ -95,20 +140,101 @@ def create_bm25_inverted_index(chunks, bm25):
         inverted_index[word].sort(key=lambda x: x['score'], reverse=True)
     return inverted_index
 
+def build_metadata_index(chunks):
+    """Build O(1) lookup indexes for tags, category, used_in, entrypoints."""
+    tag_index = {}
+    category_index = {}
+    used_in_index = {}
+    entrypoint_ids = []
+
+    for chunk in chunks:
+        cid = chunk['id']
+        for tag in chunk.get('tags', []):
+            tag_index.setdefault(tag, []).append(cid)
+        for cat in chunk.get('category', []):
+            category_index.setdefault(cat, []).append(cid)
+        for ui in chunk.get('used_in', []):
+            used_in_index.setdefault(ui, []).append(cid)
+        if chunk.get('entrypoint'):
+            entrypoint_ids.append(cid)
+
+    return {
+        'tag_index':      tag_index,
+        'category_index': category_index,
+        'used_in_index':  used_in_index,
+        'entrypoint_ids': entrypoint_ids,
+    }
+
+def _resolve_related_node(related_path, source_file_path, path_to_chunk_ids):
+    """Resolve a relative related_node path to chunk_ids."""
+    source_dir = os.path.dirname(source_file_path)
+    # Try resolving relative to the source file's directory
+    candidates = [
+        os.path.normpath(os.path.join(source_dir, related_path)),
+        os.path.normpath(os.path.join(source_dir, related_path + '.md')),
+        os.path.normpath(os.path.join(source_dir, related_path + '.yaml')),
+    ]
+    for candidate in candidates:
+        if candidate in path_to_chunk_ids:
+            return path_to_chunk_ids[candidate]
+    # Also try basename match
+    basename = os.path.basename(related_path)
+    for path, cids in path_to_chunk_ids.items():
+        if os.path.basename(path) == basename or os.path.basename(path) == basename + '.md':
+            return cids
+    return []
+
 def create_knowledge_graph_with_content(chunks, embeddings):
-    """Build knowledge graph using embedding cosine similarity."""
+    """Build knowledge graph using embedding cosine similarity + YAML related_nodes."""
     nodes, edges = [], []
+
+    # Build path -> [chunk_idx] index for related_nodes resolution
+    path_to_chunk_ids = {}
+    for chunk in chunks:
+        fp = chunk.get('file_path', '')
+        path_to_chunk_ids.setdefault(fp, []).append(chunk['id'])
+
+    # Build chunk_id -> node_id index
+    chunk_id_to_node_id = {}
     for i, chunk in enumerate(chunks):
         node_id = f"n{i + 1}"
-        nodes.append({'id': node_id, 'chunk_id': chunk['id'], 'type': chunk['type'], 'label': chunk['section']})
+        chunk_id_to_node_id[chunk['id']] = node_id
+        nodes.append({
+            'id': node_id,
+            'chunk_id': chunk['id'],
+            'type': chunk['type'],
+            'label': chunk['section'],
+            'tags': chunk.get('tags', []),
+            'category': chunk.get('category', []),
+            'used_in': chunk.get('used_in', []),
+            'entrypoint': chunk.get('entrypoint', False),
+        })
         if i > 0:
-            edges.append({'from': f"n{i}", 'to': node_id, 'type': 'refers-to', 'weight': 0.9, 'evidence_chunk_id': chunk['id']})
+            edges.append({'from': f"n{i}", 'to': node_id, 'type': 'refers-to',
+                          'weight': 0.9, 'evidence_chunk_id': chunk['id']})
 
+    # Semantic edges from cosine similarity
     cosine_sim = embeddings @ embeddings.T
     for i in range(len(chunks)):
         for j in range(i + 1, len(chunks)):
             if cosine_sim[i, j] > 0.7:
-                edges.append({'from': f"n{i + 1}", 'to': f"n{j + 1}", 'type': 'related-to', 'weight': float(cosine_sim[i, j]), 'evidence_chunk_id': chunks[i]['id']})
+                edges.append({'from': f"n{i + 1}", 'to': f"n{j + 1}", 'type': 'related-to',
+                              'weight': float(cosine_sim[i, j]), 'evidence_chunk_id': chunks[i]['id']})
+
+    # Explicit reference edges from companion YAML related_nodes
+    seen_refs = set()
+    for i, chunk in enumerate(chunks):
+        src_node = f"n{i + 1}"
+        for rel_path in chunk.get('related_nodes', []):
+            target_cids = _resolve_related_node(rel_path, chunk['file_path'], path_to_chunk_ids)
+            for tcid in target_cids:
+                dst_node = chunk_id_to_node_id.get(tcid)
+                if dst_node and dst_node != src_node:
+                    key = (src_node, dst_node)
+                    if key not in seen_refs:
+                        seen_refs.add(key)
+                        edges.append({'from': src_node, 'to': dst_node, 'type': 'references',
+                                      'weight': 1.0, 'evidence_chunk_id': chunk['id']})
 
     for i, edge in enumerate(edges):
         edge['id'] = f'e{i+1}'
@@ -116,12 +242,22 @@ def create_knowledge_graph_with_content(chunks, embeddings):
 
 def process_directory(directory_path):
     all_chunks = []
+    # Collect companion yaml paths to skip standalone processing
+    companion_yamls = set()
+    for root, _, files in os.walk(directory_path):
+        for file in files:
+            if file.endswith('.md'):
+                base = os.path.splitext(os.path.join(root, file))[0]
+                candidate = base + '.yaml'
+                if os.path.exists(candidate):
+                    companion_yamls.add(candidate)
+
     for root, _, files in os.walk(directory_path):
         for file in files:
             file_path = os.path.join(root, file)
             if file.endswith('.md'):
                 all_chunks.extend(process_md_file(file_path))
-            elif file.endswith(('.yaml', '.yml')):
+            elif file.endswith(('.yaml', '.yml')) and file_path not in companion_yamls:
                 all_chunks.extend(process_yaml_file(file_path))
     return all_chunks
 
@@ -145,6 +281,9 @@ def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
     print("Building inverted index (BM25 scores for SQLite)...")
     inverted_index = create_bm25_inverted_index(chunks_list, bm25)
 
+    print("Building metadata index (tags/category/used_in)...")
+    metadata_index = build_metadata_index(chunks_list)
+
     nodes_list, edges_list = create_knowledge_graph_with_content(chunks_list, embeddings)
 
     for edge in edges_list:
@@ -158,6 +297,7 @@ def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
         "nodes": {item['id']: item for item in nodes_list},
         "edges": {item['id']: item for item in edges_list},
         "inverted_index": inverted_index,
+        "metadata_index": metadata_index,
         "bm25": bm25,
         "bm25_chunk_ids": [c['id'] for c in chunks_list],
         "faiss_index": faiss_index,
@@ -169,7 +309,7 @@ def save_knowledge_base_legacy(kb_data, output_dir="kb_data", save_json=True, sa
     os.makedirs(output_dir, exist_ok=True)
     if save_json: os.makedirs(os.path.join(output_dir, 'json'), exist_ok=True)
     if save_pickle: os.makedirs(os.path.join(output_dir, 'pkl'), exist_ok=True)
-    
+
     legacy_data = {
         "chunks": kb_data.get("chunks", {}),
         "graph_nodes": kb_data.get("nodes", {}),
@@ -181,6 +321,10 @@ def save_knowledge_base_legacy(kb_data, output_dir="kb_data", save_json=True, sa
         for name, data in legacy_data.items():
             with open(os.path.join(output_dir, 'json', f"{name}.json"), 'w', encoding='utf-8') as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)
+        meta_idx = kb_data.get("metadata_index", {})
+        with open(os.path.join(output_dir, 'json', 'metadata_index.json'), 'w', encoding='utf-8') as f:
+            json.dump(meta_idx, f, ensure_ascii=False, indent=2)
+
     if save_pickle:
         for name, data in legacy_data.items():
             with open(os.path.join(output_dir, 'pkl', f"{name}.pkl"), 'wb') as f:
@@ -203,6 +347,10 @@ def save_knowledge_base_legacy(kb_data, output_dir="kb_data", save_json=True, sa
         with open(os.path.join(output_dir, 'pkl', 'model_name.pkl'), 'wb') as f:
             pickle.dump(kb_data.get("model_name", EMBEDDING_MODEL), f)
 
+        meta_idx = kb_data.get("metadata_index", {})
+        with open(os.path.join(output_dir, 'pkl', 'metadata_index.pkl'), 'wb') as f:
+            pickle.dump(meta_idx, f)
+
 def save_kb_to_sqlite(kb_data, output_dir="sqlite_data"):
     os.makedirs(output_dir, exist_ok=True)
     db_path = os.path.join(output_dir, 'knowledge_base.sqlite')
@@ -222,7 +370,7 @@ def save_kb_to_sqlite(kb_data, output_dir="sqlite_data"):
 
     files_map = {path: i + 1 for i, path in enumerate(sorted(list(set(c['file_path'] for c in kb_data['chunks'].values()))))}
     cursor.executemany("INSERT INTO files (id, path) VALUES (?, ?)", [(i, p) for p, i in files_map.items()])
-    
+
     terms_map = {term: i + 1 for i, term in enumerate(sorted(kb_data['inverted_index'].keys()))}
     cursor.executemany("INSERT INTO terms (id, term) VALUES (?, ?)", [(i, t) for t, i in terms_map.items()])
 
@@ -230,7 +378,7 @@ def save_kb_to_sqlite(kb_data, output_dir="sqlite_data"):
     cursor.executemany("INSERT INTO chunks VALUES (?, ?, ?, ?, ?, ?, ?, ?)", chunk_data)
 
     cursor.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?)", [(n['id'], n['chunk_id'], n['type'], n['label']) for n in kb_data['nodes'].values()])
-    
+
     edge_data = [(e['id'], e['from'], e['to'], e['type'], e.get('weight', 1.0)) for e in kb_data['edges'].values()]
     cursor.executemany("INSERT INTO edges VALUES (?, ?, ?, ?, ?)", edge_data)
 
@@ -246,6 +394,16 @@ def save_kb_to_sqlite(kb_data, output_dir="sqlite_data"):
                     inverted_index_data.append((term_id, entry['chunk_id'], entry['score']))
     cursor.executemany("INSERT INTO inverted_index VALUES (?, ?, ?)", inverted_index_data)
 
+    # Metadata index tables
+    tag_rows = [(cid, tag) for tag, cids in kb_data.get('metadata_index', {}).get('tag_index', {}).items() for cid in cids]
+    cursor.executemany("INSERT INTO chunk_tags (chunk_id, tag) VALUES (?, ?)", tag_rows)
+
+    cat_rows = [(cid, cat) for cat, cids in kb_data.get('metadata_index', {}).get('category_index', {}).items() for cid in cids]
+    cursor.executemany("INSERT INTO chunk_categories (chunk_id, category) VALUES (?, ?)", cat_rows)
+
+    ui_rows = [(cid, ui) for ui, cids in kb_data.get('metadata_index', {}).get('used_in_index', {}).items() for cid in cids]
+    cursor.executemany("INSERT INTO chunk_used_in (chunk_id, used_in) VALUES (?, ?)", ui_rows)
+
     for table in schema['tables']:
         if 'indexes' in table:
             for index in table['indexes']:
@@ -259,14 +417,14 @@ def save_kb_to_sqlite(kb_data, output_dir="sqlite_data"):
 def generate_edge_types_doc(kb_data, output_dir="kb_data"):
     """Generates a markdown file documenting all unique edge types."""
     edge_types = sorted(list(set(edge['type'] for edge in kb_data['edges'].values())))
-    
+
     content = "# Edge Types Documentation\n\n"
     content += "This document lists all unique edge types automatically discovered in the knowledge graph.\n\n"
     content += "Understanding these relationships is key to querying and interpreting the graph's structure.\n\n"
-    
+
     for edge_type in edge_types:
         content += f"- `{edge_type}`\n"
-        
+
     doc_path = os.path.join(output_dir, 'edge_types.md')
     with open(doc_path, 'w', encoding='utf-8') as f:
         f.write(content)
@@ -280,7 +438,7 @@ if __name__ == "__main__":
     sqlite_output_path = './sqlite_data'
 
     kb_objects = build_knowledge_base(source_path)
-    
+
     save_knowledge_base_legacy(kb_objects, output_dir=legacy_output_path, save_json=True, save_pickle=True)
     save_kb_to_sqlite(kb_objects, output_dir=sqlite_output_path)
     generate_edge_types_doc(kb_objects, output_dir=legacy_output_path)
@@ -289,9 +447,15 @@ if __name__ == "__main__":
     print(f"Total chunks: {len(kb_objects['chunks'])}")
     print(f"Total nodes: {len(kb_objects['nodes'])}")
     print(f"Total edges: {len(kb_objects['edges'])}")
-    
+
+    meta = kb_objects.get('metadata_index', {})
+    print(f"Unique tags: {len(meta.get('tag_index', {}))}")
+    print(f"Unique categories: {len(meta.get('category_index', {}))}")
+    print(f"Unique used_in: {len(meta.get('used_in_index', {}))}")
+    print(f"Entrypoints: {len(meta.get('entrypoint_ids', []))}")
+
     print(f"\nSuccessfully created legacy data files in '{legacy_output_path}/'")
     print(f"Successfully created SQLite DB in '{sqlite_output_path}/'")
-    
+
     db_size = os.path.getsize(os.path.join(sqlite_output_path, 'knowledge_base.sqlite'))
     print(f"SQLite database size: {db_size / 1024 / 1024:.2f} MB")

--- a/make_source.py
+++ b/make_source.py
@@ -6,27 +6,14 @@ import datetime
 import pickle
 import sqlite3
 import re
+import numpy as np
 from bs4 import BeautifulSoup
 from langdetect import detect, LangDetectException
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.metrics.pairwise import cosine_similarity
+from sentence_transformers import SentenceTransformer
+from rank_bm25 import BM25Okapi
+import faiss
 
-# --- NLTK Setup ---
-try:
-    from nltk.corpus import stopwords
-    import nltk
-    nltk.download('stopwords', quiet=True)
-    nltk.download('punkt', quiet=True)
-except ImportError:
-    print("NLTK not found. Please install it: pip install nltk")
-    stopwords = None
-
-# --- Data Processing Functions ---
-
-def get_stop_words(lang):
-    if not stopwords: return set()
-    language_map = {'hu': 'hungarian', 'en': 'english'}
-    return set(stopwords.words(language_map[lang])) if lang in language_map else set()
+EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "paraphrase-multilingual-MiniLM-L12-v2")
 
 def detect_language(text):
     try:
@@ -76,40 +63,53 @@ def process_yaml_file(file_path):
     except (yaml.YAMLError, IOError):
         return []
 
-def clean_text(text, lang):
-    stop_words = get_stop_words(lang)
-    return ' '.join([word for word in text.lower().split() if word.isalpha() and word not in stop_words])
+def create_embeddings(texts, model_name=EMBEDDING_MODEL):
+    """Encode texts using a multilingual sentence transformer model."""
+    print(f"Loading embedding model: {model_name}")
+    model = SentenceTransformer(model_name)
+    embeddings = model.encode(texts, show_progress_bar=True, normalize_embeddings=True, batch_size=64)
+    return model, np.array(embeddings, dtype='float32')
 
-def create_tfidf_vectorizer_and_matrix(texts):
-    vectorizer = TfidfVectorizer(stop_words=None, min_df=5, max_df=0.7)
-    return vectorizer, vectorizer.fit_transform(texts)
+def build_faiss_index(embeddings):
+    """Build FAISS inner-product index (cosine sim with normalized vectors)."""
+    dim = embeddings.shape[1]
+    index = faiss.IndexFlatIP(dim)
+    index.add(embeddings)
+    return index
 
-def create_inverted_index(chunks, tfidf_matrix, vectorizer):
+def build_bm25_index(chunks):
+    """Build BM25 index for lexical search."""
+    tokenized = [chunk['text'].lower().split() for chunk in chunks]
+    return BM25Okapi(tokenized)
+
+def create_bm25_inverted_index(chunks, bm25):
+    """Lightweight inverted index from BM25 scores (for SQLite compat)."""
     inverted_index = {}
-    feature_names = vectorizer.get_feature_names_out()
-    rows, cols = tfidf_matrix.nonzero()
-    for row, col in zip(rows, cols):
-        word, chunk_id, score = feature_names[col], chunks[row]['id'], tfidf_matrix[row, col]
-        if score < 0.01: continue
-        if word not in inverted_index: inverted_index[word] = []
-        inverted_index[word].append({'chunk_id': chunk_id, 'score': float(score)})
-    for word in inverted_index: inverted_index[word].sort(key=lambda x: x['score'], reverse=True)
+    for i, chunk in enumerate(chunks):
+        tokens = set(chunk['text'].lower().split())
+        for word in tokens:
+            score = float(bm25.get_scores([word])[i])
+            if score > 0.01:
+                inverted_index.setdefault(word, []).append({'chunk_id': chunk['id'], 'score': score})
+    for word in inverted_index:
+        inverted_index[word].sort(key=lambda x: x['score'], reverse=True)
     return inverted_index
 
-def create_knowledge_graph_with_content(chunks, tfidf_matrix):
+def create_knowledge_graph_with_content(chunks, embeddings):
+    """Build knowledge graph using embedding cosine similarity."""
     nodes, edges = [], []
     for i, chunk in enumerate(chunks):
         node_id = f"n{i + 1}"
         nodes.append({'id': node_id, 'chunk_id': chunk['id'], 'type': chunk['type'], 'label': chunk['section']})
         if i > 0:
             edges.append({'from': f"n{i}", 'to': node_id, 'type': 'refers-to', 'weight': 0.9, 'evidence_chunk_id': chunk['id']})
-    
-    cosine_sim = cosine_similarity(tfidf_matrix, tfidf_matrix)
+
+    cosine_sim = embeddings @ embeddings.T
     for i in range(len(chunks)):
         for j in range(i + 1, len(chunks)):
             if cosine_sim[i, j] > 0.7:
                 edges.append({'from': f"n{i + 1}", 'to': f"n{j + 1}", 'type': 'related-to', 'weight': float(cosine_sim[i, j]), 'evidence_chunk_id': chunks[i]['id']})
-    
+
     for i, edge in enumerate(edges):
         edge['id'] = f'e{i+1}'
     return nodes, edges
@@ -125,19 +125,28 @@ def process_directory(directory_path):
                 all_chunks.extend(process_yaml_file(file_path))
     return all_chunks
 
-def build_knowledge_base(source_directory):
+def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
     chunks_list = process_directory(source_directory)
     chunks_list.sort(key=lambda x: (x['file_path'], x['start_line']))
     for i, chunk in enumerate(chunks_list):
         chunk['id'] = f'c{i+1}'
-    
-    cleaned_texts = [clean_text(chunk['text'], chunk['lang']) for chunk in chunks_list]
-    vectorizer, tfidf_matrix = create_tfidf_vectorizer_and_matrix(cleaned_texts)
-    
-    temp_inverted_index = create_inverted_index(chunks_list, tfidf_matrix, vectorizer)
-    
-    nodes_list, edges_list = create_knowledge_graph_with_content(chunks_list, tfidf_matrix)
-    
+
+    texts = [chunk['text'] for chunk in chunks_list]
+
+    print("Building embeddings...")
+    model, embeddings = create_embeddings(texts, model_name)
+
+    print("Building BM25 index...")
+    bm25 = build_bm25_index(chunks_list)
+
+    print("Building FAISS index...")
+    faiss_index = build_faiss_index(embeddings)
+
+    print("Building inverted index (BM25 scores for SQLite)...")
+    inverted_index = create_bm25_inverted_index(chunks_list, bm25)
+
+    nodes_list, edges_list = create_knowledge_graph_with_content(chunks_list, embeddings)
+
     for edge in edges_list:
         if 'evidence_chunk_id' in edge:
             chunk = next((c for c in chunks_list if c['id'] == edge['evidence_chunk_id']), None)
@@ -148,9 +157,11 @@ def build_knowledge_base(source_directory):
         "chunks": {item['id']: item for item in chunks_list},
         "nodes": {item['id']: item for item in nodes_list},
         "edges": {item['id']: item for item in edges_list},
-        "inverted_index": temp_inverted_index,
-        "vectorizer": vectorizer,
-        "tfidf_matrix": tfidf_matrix
+        "inverted_index": inverted_index,
+        "bm25": bm25,
+        "bm25_chunk_ids": [c['id'] for c in chunks_list],
+        "faiss_index": faiss_index,
+        "model_name": model_name,
     }
 
 def save_knowledge_base_legacy(kb_data, output_dir="kb_data", save_json=True, save_pickle=True):
@@ -174,6 +185,23 @@ def save_knowledge_base_legacy(kb_data, output_dir="kb_data", save_json=True, sa
         for name, data in legacy_data.items():
             with open(os.path.join(output_dir, 'pkl', f"{name}.pkl"), 'wb') as f:
                 pickle.dump(data, f)
+
+        faiss_index = kb_data.get("faiss_index")
+        if faiss_index is not None:
+            faiss.write_index(faiss_index, os.path.join(output_dir, 'pkl', 'faiss.index'))
+
+        bm25 = kb_data.get("bm25")
+        if bm25 is not None:
+            with open(os.path.join(output_dir, 'pkl', 'bm25.pkl'), 'wb') as f:
+                pickle.dump(bm25, f)
+
+        bm25_chunk_ids = kb_data.get("bm25_chunk_ids")
+        if bm25_chunk_ids is not None:
+            with open(os.path.join(output_dir, 'pkl', 'chunk_ids.pkl'), 'wb') as f:
+                pickle.dump(bm25_chunk_ids, f)
+
+        with open(os.path.join(output_dir, 'pkl', 'model_name.pkl'), 'wb') as f:
+            pickle.dump(kb_data.get("model_name", EMBEDDING_MODEL), f)
 
 def save_kb_to_sqlite(kb_data, output_dir="sqlite_data"):
     os.makedirs(output_dir, exist_ok=True)

--- a/make_source.py
+++ b/make_source.py
@@ -1,0 +1,269 @@
+import os
+import yaml
+import markdown
+import json
+import datetime
+import pickle
+import sqlite3
+import re
+from bs4 import BeautifulSoup
+from langdetect import detect, LangDetectException
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+# --- NLTK Setup ---
+try:
+    from nltk.corpus import stopwords
+    import nltk
+    nltk.download('stopwords', quiet=True)
+    nltk.download('punkt', quiet=True)
+except ImportError:
+    print("NLTK not found. Please install it: pip install nltk")
+    stopwords = None
+
+# --- Data Processing Functions ---
+
+def get_stop_words(lang):
+    if not stopwords: return set()
+    language_map = {'hu': 'hungarian', 'en': 'english'}
+    return set(stopwords.words(language_map[lang])) if lang in language_map else set()
+
+def detect_language(text):
+    try:
+        return detect(text)
+    except LangDetectException:
+        return 'unknown'
+
+def process_md_file(file_path):
+    chunks = []
+    with open(file_path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+    current_chunk_lines, current_header, start_line = [], "", 1
+    for i, line in enumerate(lines):
+        match = re.match(r'^(#+)\s(.*)', line)
+        if match:
+            if current_chunk_lines:
+                text = "".join(current_chunk_lines).strip()
+                if text: chunks.append({'text': text, 'file_path': file_path, 'section': current_header, 'start_line': start_line, 'end_line': i, 'lang': detect_language(text), 'type': 'section'})
+            start_line = i + 1
+            current_header = match.group(2).strip()
+            current_chunk_lines = [line]
+        else:
+            current_chunk_lines.append(line)
+    if current_chunk_lines:
+        text = "".join(current_chunk_lines).strip()
+        if text: chunks.append({'text': text, 'file_path': file_path, 'section': current_header, 'start_line': start_line, 'end_line': len(lines), 'lang': detect_language(text), 'type': 'section'})
+    return chunks
+
+def process_yaml_file(file_path):
+    """Processes a YAML file as a single, large chunk to preserve context."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as file:
+            yaml_content = yaml.safe_load(file)
+            if not yaml_content:
+                return []
+            # Dump the whole yaml content into a single text block
+            text_content = yaml.dump(yaml_content, allow_unicode=True, default_flow_style=False, indent=2)
+            return [{
+                'text': text_content,
+                'file_path': file_path,
+                'section': os.path.basename(file_path),
+                'start_line': 1,
+                'end_line': len(text_content.splitlines()),
+                'lang': 'yaml',
+                'type': 'yaml_file'
+            }]
+    except (yaml.YAMLError, IOError):
+        return []
+
+def clean_text(text, lang):
+    stop_words = get_stop_words(lang)
+    return ' '.join([word for word in text.lower().split() if word.isalpha() and word not in stop_words])
+
+def create_tfidf_vectorizer_and_matrix(texts):
+    vectorizer = TfidfVectorizer(stop_words=None, min_df=5, max_df=0.7)
+    return vectorizer, vectorizer.fit_transform(texts)
+
+def create_inverted_index(chunks, tfidf_matrix, vectorizer):
+    inverted_index = {}
+    feature_names = vectorizer.get_feature_names_out()
+    rows, cols = tfidf_matrix.nonzero()
+    for row, col in zip(rows, cols):
+        word, chunk_id, score = feature_names[col], chunks[row]['id'], tfidf_matrix[row, col]
+        if score < 0.01: continue
+        if word not in inverted_index: inverted_index[word] = []
+        inverted_index[word].append({'chunk_id': chunk_id, 'score': float(score)})
+    for word in inverted_index: inverted_index[word].sort(key=lambda x: x['score'], reverse=True)
+    return inverted_index
+
+def create_knowledge_graph_with_content(chunks, tfidf_matrix):
+    nodes, edges = [], []
+    for i, chunk in enumerate(chunks):
+        node_id = f"n{i + 1}"
+        nodes.append({'id': node_id, 'chunk_id': chunk['id'], 'type': chunk['type'], 'label': chunk['section']})
+        if i > 0:
+            edges.append({'from': f"n{i}", 'to': node_id, 'type': 'refers-to', 'weight': 0.9, 'evidence_chunk_id': chunk['id']})
+    
+    cosine_sim = cosine_similarity(tfidf_matrix, tfidf_matrix)
+    for i in range(len(chunks)):
+        for j in range(i + 1, len(chunks)):
+            if cosine_sim[i, j] > 0.7:
+                edges.append({'from': f"n{i + 1}", 'to': f"n{j + 1}", 'type': 'related-to', 'weight': float(cosine_sim[i, j]), 'evidence_chunk_id': chunks[i]['id']})
+    
+    for i, edge in enumerate(edges):
+        edge['id'] = f'e{i+1}'
+    return nodes, edges
+
+def process_directory(directory_path):
+    all_chunks = []
+    for root, _, files in os.walk(directory_path):
+        for file in files:
+            file_path = os.path.join(root, file)
+            if file.endswith('.md'):
+                all_chunks.extend(process_md_file(file_path))
+            elif file.endswith(('.yaml', '.yml')):
+                all_chunks.extend(process_yaml_file(file_path))
+    return all_chunks
+
+def build_knowledge_base(source_directory):
+    chunks_list = process_directory(source_directory)
+    chunks_list.sort(key=lambda x: (x['file_path'], x['start_line']))
+    for i, chunk in enumerate(chunks_list):
+        chunk['id'] = f'c{i+1}'
+    
+    cleaned_texts = [clean_text(chunk['text'], chunk['lang']) for chunk in chunks_list]
+    vectorizer, tfidf_matrix = create_tfidf_vectorizer_and_matrix(cleaned_texts)
+    
+    temp_inverted_index = create_inverted_index(chunks_list, tfidf_matrix, vectorizer)
+    
+    nodes_list, edges_list = create_knowledge_graph_with_content(chunks_list, tfidf_matrix)
+    
+    for edge in edges_list:
+        if 'evidence_chunk_id' in edge:
+            chunk = next((c for c in chunks_list if c['id'] == edge['evidence_chunk_id']), None)
+            if chunk:
+                edge['evidence'] = [{'file': chunk['file_path'], 'start_line': chunk['start_line'], 'end_line': chunk['end_line']}]
+
+    return {
+        "chunks": {item['id']: item for item in chunks_list},
+        "nodes": {item['id']: item for item in nodes_list},
+        "edges": {item['id']: item for item in edges_list},
+        "inverted_index": temp_inverted_index,
+        "vectorizer": vectorizer,
+        "tfidf_matrix": tfidf_matrix
+    }
+
+def save_knowledge_base_legacy(kb_data, output_dir="kb_data", save_json=True, save_pickle=True):
+    if not (save_json or save_pickle): return
+    os.makedirs(output_dir, exist_ok=True)
+    if save_json: os.makedirs(os.path.join(output_dir, 'json'), exist_ok=True)
+    if save_pickle: os.makedirs(os.path.join(output_dir, 'pkl'), exist_ok=True)
+    
+    legacy_data = {
+        "chunks": kb_data.get("chunks", {}),
+        "graph_nodes": kb_data.get("nodes", {}),
+        "inverted_index": kb_data.get("inverted_index", {}),
+        "graph_edges": kb_data.get("edges", {})
+    }
+
+    if save_json:
+        for name, data in legacy_data.items():
+            with open(os.path.join(output_dir, 'json', f"{name}.json"), 'w', encoding='utf-8') as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+    if save_pickle:
+        for name, data in legacy_data.items():
+            with open(os.path.join(output_dir, 'pkl', f"{name}.pkl"), 'wb') as f:
+                pickle.dump(data, f)
+
+def save_kb_to_sqlite(kb_data, output_dir="sqlite_data"):
+    os.makedirs(output_dir, exist_ok=True)
+    db_path = os.path.join(output_dir, 'knowledge_base.sqlite')
+    schema_path = os.path.join(output_dir, 'db_schema.json')
+    if os.path.exists(db_path): os.remove(db_path)
+
+    with open(schema_path, 'r', encoding='utf-8') as f: schema = json.load(f)
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA foreign_keys = ON;")
+
+    for table in schema['tables']:
+        cols = ", ".join([f'"{c["name"]}" {c["type"]}' for c in table["columns"]])
+        pk = table.get("primary_key", [])
+        pk_str = f', PRIMARY KEY({", ".join(pk)})' if pk else ''
+        cursor.execute(f"CREATE TABLE {table['name']} ({cols}{pk_str})")
+
+    files_map = {path: i + 1 for i, path in enumerate(sorted(list(set(c['file_path'] for c in kb_data['chunks'].values()))))}
+    cursor.executemany("INSERT INTO files (id, path) VALUES (?, ?)", [(i, p) for p, i in files_map.items()])
+    
+    terms_map = {term: i + 1 for i, term in enumerate(sorted(kb_data['inverted_index'].keys()))}
+    cursor.executemany("INSERT INTO terms (id, term) VALUES (?, ?)", [(i, t) for t, i in terms_map.items()])
+
+    chunk_data = [(c['id'], files_map[c['file_path']], c['text'], c['section'], c['start_line'], c['end_line'], c['lang'], c['type']) for c in kb_data['chunks'].values()]
+    cursor.executemany("INSERT INTO chunks VALUES (?, ?, ?, ?, ?, ?, ?, ?)", chunk_data)
+
+    cursor.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?)", [(n['id'], n['chunk_id'], n['type'], n['label']) for n in kb_data['nodes'].values()])
+    
+    edge_data = [(e['id'], e['from'], e['to'], e['type'], e.get('weight', 1.0)) for e in kb_data['edges'].values()]
+    cursor.executemany("INSERT INTO edges VALUES (?, ?, ?, ?, ?)", edge_data)
+
+    evidence_data = [(e['id'], e['evidence_chunk_id']) for e in kb_data['edges'].values() if 'evidence_chunk_id' in e]
+    cursor.executemany("INSERT INTO edge_evidence VALUES (?, ?)", evidence_data)
+
+    inverted_index_data = []
+    for term, entries in kb_data['inverted_index'].items():
+        term_id = terms_map.get(term)
+        if term_id:
+            for entry in entries:
+                if entry['score'] > 0.01:
+                    inverted_index_data.append((term_id, entry['chunk_id'], entry['score']))
+    cursor.executemany("INSERT INTO inverted_index VALUES (?, ?, ?)", inverted_index_data)
+
+    for table in schema['tables']:
+        if 'indexes' in table:
+            for index in table['indexes']:
+                cursor.execute(f"CREATE INDEX IF NOT EXISTS {index['name']} ON {table['name']} ({', '.join(index['columns'])})")
+
+    conn.commit()
+    cursor.execute("VACUUM;")
+    cursor.execute("ANALYZE;")
+    conn.close()
+
+def generate_edge_types_doc(kb_data, output_dir="kb_data"):
+    """Generates a markdown file documenting all unique edge types."""
+    edge_types = sorted(list(set(edge['type'] for edge in kb_data['edges'].values())))
+    
+    content = "# Edge Types Documentation\n\n"
+    content += "This document lists all unique edge types automatically discovered in the knowledge graph.\n\n"
+    content += "Understanding these relationships is key to querying and interpreting the graph's structure.\n\n"
+    
+    for edge_type in edge_types:
+        content += f"- `{edge_type}`\n"
+        
+    doc_path = os.path.join(output_dir, 'edge_types.md')
+    with open(doc_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+    print(f"Successfully generated edge types documentation at '{doc_path}'")
+
+
+if __name__ == "__main__":
+    print("Starting knowledge base generation...")
+    source_path = './source'
+    legacy_output_path = './kb_data'
+    sqlite_output_path = './sqlite_data'
+
+    kb_objects = build_knowledge_base(source_path)
+    
+    save_knowledge_base_legacy(kb_objects, output_dir=legacy_output_path, save_json=True, save_pickle=True)
+    save_kb_to_sqlite(kb_objects, output_dir=sqlite_output_path)
+    generate_edge_types_doc(kb_objects, output_dir=legacy_output_path)
+
+    print("\n--- Generation Complete ---")
+    print(f"Total chunks: {len(kb_objects['chunks'])}")
+    print(f"Total nodes: {len(kb_objects['nodes'])}")
+    print(f"Total edges: {len(kb_objects['edges'])}")
+    
+    print(f"\nSuccessfully created legacy data files in '{legacy_output_path}/'")
+    print(f"Successfully created SQLite DB in '{sqlite_output_path}/'")
+    
+    db_size = os.path.getsize(os.path.join(sqlite_output_path, 'knowledge_base.sqlite'))
+    print(f"SQLite database size: {db_size / 1024 / 1024:.2f} MB")

--- a/make_source.py
+++ b/make_source.py
@@ -86,6 +86,79 @@ def process_md_file(file_path):
             chunks.append(chunk)
     return chunks
 
+def process_go_yaml(file_path):
+    """Process a .go.yaml companion file as structured knowledge chunks.
+
+    The .go source file is not indexed (code excluded by design); this YAML
+    is the sole knowledge source for Go files in the KB.
+
+    Produces one chunk per object defined in the file.
+    File-level metadata (tags, category, used_in) is applied to all chunks.
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            return []
+    except (yaml.YAMLError, IOError):
+        return []
+
+    meta = {
+        'tags':          _normalize_list(data.get('tags')),
+        'category':      _normalize_list(data.get('category')),
+        'used_in':       _normalize_list(data.get('used_in')),
+        'related_nodes': _normalize_list(data.get('related_nodes')),
+        'entrypoint':    bool(data.get('entrypoint', False)),
+        'description':   str(data.get('description', '')).strip(),
+    }
+
+    package = data.get('package', '') or os.path.basename(file_path)
+    objects = data.get('objects', [])
+
+    if not objects:
+        text = f"package {package}"
+        if meta['description']:
+            text += f"\n{meta['description']}"
+        return [{
+            'text': text, 'file_path': file_path,
+            'section': package, 'start_line': 1, 'end_line': 1,
+            'lang': 'go', 'type': 'go_package', **meta,
+        }]
+
+    chunks = []
+    for i, obj in enumerate(objects):
+        name     = obj.get('name', '')
+        kind     = obj.get('kind', '')
+        receiver = obj.get('receiver', '')
+        desc     = str(obj.get('description', '')).strip()
+        refs     = obj.get('references', [])
+        impl     = obj.get('implements', [])
+
+        # Build searchable text: signature + description + references
+        sig = f"method ({receiver}) {name}" if receiver else f"{kind} {name}"
+        lines = [sig]
+        if desc:
+            lines.append(desc)
+        if refs:
+            lines.append(f"references: {', '.join(refs)}")
+        if impl:
+            lines.append(f"implements: {', '.join(impl)}")
+
+        chunk = {
+            'text': '\n'.join(lines),
+            'file_path': file_path,
+            'section': name,
+            'start_line': i + 1,
+            'end_line': i + 1,
+            'lang': 'go',
+            'type': f'go_{kind}' if kind else 'go_object',
+        }
+        chunk.update(meta)
+        chunks.append(chunk)
+
+    return chunks
+
+
 def process_yaml_file(file_path):
     """Processes a YAML file as a single, large chunk to preserve context."""
     try:
@@ -242,23 +315,35 @@ def create_knowledge_graph_with_content(chunks, embeddings):
 
 def process_directory(directory_path):
     all_chunks = []
-    # Collect companion yaml paths to skip standalone processing
-    companion_yamls = set()
+
+    # First pass: classify YAML files by their sibling source file type
+    md_companion_yamls = set()   # .yaml next to .md  → merged into md chunks, skip standalone
+    go_companion_yamls = set()   # .yaml next to .go  → process via process_go_yaml
+
     for root, _, files in os.walk(directory_path):
         for file in files:
+            base = os.path.splitext(os.path.join(root, file))[0]
             if file.endswith('.md'):
-                base = os.path.splitext(os.path.join(root, file))[0]
                 candidate = base + '.yaml'
                 if os.path.exists(candidate):
-                    companion_yamls.add(candidate)
+                    md_companion_yamls.add(candidate)
+            elif file.endswith('.go'):
+                candidate = base + '.yaml'
+                if os.path.exists(candidate):
+                    go_companion_yamls.add(candidate)
 
+    # Second pass: process files with correct handler
     for root, _, files in os.walk(directory_path):
         for file in files:
             file_path = os.path.join(root, file)
             if file.endswith('.md'):
                 all_chunks.extend(process_md_file(file_path))
-            elif file.endswith(('.yaml', '.yml')) and file_path not in companion_yamls:
-                all_chunks.extend(process_yaml_file(file_path))
+            elif file.endswith(('.yaml', '.yml')):
+                if file_path in go_companion_yamls:
+                    all_chunks.extend(process_go_yaml(file_path))
+                elif file_path not in md_companion_yamls:
+                    all_chunks.extend(process_yaml_file(file_path))
+
     return all_chunks
 
 def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):

--- a/make_source.py
+++ b/make_source.py
@@ -178,6 +178,93 @@ def process_go_yaml(file_path):
     return chunks
 
 
+def process_py_yaml(file_path):
+    """Process a .py.yaml companion file as structured knowledge chunks.
+
+    Mirrors process_go_yaml: the .py source file is not indexed directly
+    (code excluded by design); this YAML is the sole knowledge source for
+    Python files in the KB.
+
+    Produces one chunk per object defined in the file.
+    File-level metadata (tags, category, used_in) is applied to all chunks.
+    """
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            return []
+    except (yaml.YAMLError, IOError):
+        return []
+
+    meta = {
+        'tags':          _normalize_list(data.get('tags')),
+        'category':      _normalize_list(data.get('category')),
+        'used_in':       _normalize_list(data.get('used_in')),
+        'related_nodes': _normalize_list(data.get('related_nodes')),
+        'entrypoint':    bool(data.get('entrypoint', False)),
+        'description':   str(data.get('description', '')).strip(),
+    }
+
+    module = data.get('module', '') or os.path.basename(file_path)
+    objects = data.get('objects', [])
+
+    # Module-level chunk: always emitted, aggregates file path + all object names/descriptions
+    py_file = os.path.splitext(file_path)[0] + '.py'
+    mod_lines = [f"module {module}", f"file: {os.path.basename(file_path)}", f"source: {os.path.basename(py_file)}"]
+    if meta['description']:
+        mod_lines.append(meta['description'])
+    if objects:
+        mod_lines.append("contains: " + ", ".join(o.get('name', '') for o in objects))
+        for obj in objects:
+            name = obj.get('name', '')
+            desc = str(obj.get('description', '')).strip()
+            if desc:
+                mod_lines.append(f"{name}: {desc}")
+    chunks = [{
+        'text': '\n'.join(mod_lines), 'file_path': file_path,
+        'section': module, 'start_line': 1, 'end_line': 1,
+        'lang': 'python', 'type': 'py_module', **meta,
+    }]
+
+    if not objects:
+        return chunks
+
+    for i, obj in enumerate(objects):
+        name       = obj.get('name', '')
+        kind       = obj.get('kind', '')
+        receiver   = obj.get('receiver', '')
+        decorators = obj.get('decorators', [])
+        desc       = str(obj.get('description', '')).strip()
+        refs       = obj.get('references', [])
+        impl       = obj.get('implements', [])
+
+        # Build searchable text: signature + description + references
+        sig = f"method ({receiver}) {name}" if receiver else f"{kind} {name}"
+        lines = [sig]
+        if decorators:
+            lines.append(f"decorators: {', '.join(decorators)}")
+        if desc:
+            lines.append(desc)
+        if refs:
+            lines.append(f"references: {', '.join(refs)}")
+        if impl:
+            lines.append(f"implements: {', '.join(impl)}")
+
+        chunk = {
+            'text': '\n'.join(lines),
+            'file_path': file_path,
+            'section': name,
+            'start_line': i + 1,
+            'end_line': i + 1,
+            'lang': 'python',
+            'type': f'py_{kind}' if kind else 'py_object',
+        }
+        chunk.update(meta)
+        chunks.append(chunk)
+
+    return chunks
+
+
 def process_yaml_file(file_path):
     """Processes a YAML file as a single, large chunk to preserve context."""
     try:
@@ -386,12 +473,24 @@ def _is_go_meta_yaml(file_path):
         return False
 
 
+def _is_py_meta_yaml(file_path):
+    """Return True if the YAML file is a Python meta companion (has 'module' + 'objects').
+    Used when the sibling .py file is absent (e.g. in docs-only submodules)."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+        return isinstance(data, dict) and 'module' in data and 'objects' in data
+    except Exception:
+        return False
+
+
 def process_directory(directory_path):
     all_chunks = []
 
     # First pass: classify YAML files by their sibling source file type
     md_companion_yamls = set()   # .yaml next to .md  → merged into md chunks, skip standalone
     go_companion_yamls = set()   # .yaml next to .go  → process via process_go_yaml
+    py_companion_yamls = set()   # .yaml next to .py  → process via process_py_yaml
 
     for root, _, files in os.walk(directory_path):
         for file in files:
@@ -404,6 +503,10 @@ def process_directory(directory_path):
                 candidate = base + '.yaml'
                 if os.path.exists(candidate):
                     go_companion_yamls.add(candidate)
+            elif file.endswith('.py'):
+                candidate = base + '.yaml'
+                if os.path.exists(candidate):
+                    py_companion_yamls.add(candidate)
 
     # Second pass: process files with correct handler
     for root, _, files in os.walk(directory_path):
@@ -414,11 +517,16 @@ def process_directory(directory_path):
             elif file.endswith(('.yaml', '.yml')):
                 if file_path in go_companion_yamls:
                     all_chunks.extend(process_go_yaml(file_path))
+                elif file_path in py_companion_yamls:
+                    all_chunks.extend(process_py_yaml(file_path))
                 elif file_path in md_companion_yamls:
                     pass  # handled by process_md_file
                 elif _is_go_meta_yaml(file_path):
                     # Go meta YAML without sibling .go (e.g. in docs-only submodule)
                     all_chunks.extend(process_go_yaml(file_path))
+                elif _is_py_meta_yaml(file_path):
+                    # Python meta YAML without sibling .py (e.g. in docs-only submodule)
+                    all_chunks.extend(process_py_yaml(file_path))
                 else:
                     all_chunks.extend(process_yaml_file(file_path))
 

--- a/make_source.py
+++ b/make_source.py
@@ -6,6 +6,7 @@ import datetime
 import pickle
 import sqlite3
 import re
+import hashlib
 import numpy as np
 from bs4 import BeautifulSoup
 from langdetect import detect, LangDetectException
@@ -14,6 +15,14 @@ from rank_bm25 import BM25Okapi
 import faiss
 
 EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "paraphrase-multilingual-MiniLM-L12-v2")
+
+def tokenize(text):
+    text = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1 \2', text)
+    text = re.sub(r'([a-z\d])([A-Z])', r'\1 \2', text)
+    tokens = text.lower().split()
+    stripped = [t.strip('.,;:()[]{}"\'/\\') for t in tokens]
+    return [t for t in stripped if t]
+
 
 def detect_language(text):
     try:
@@ -115,17 +124,27 @@ def process_go_yaml(file_path):
     package = data.get('package', '') or os.path.basename(file_path)
     objects = data.get('objects', [])
 
-    if not objects:
-        text = f"package {package}"
-        if meta['description']:
-            text += f"\n{meta['description']}"
-        return [{
-            'text': text, 'file_path': file_path,
-            'section': package, 'start_line': 1, 'end_line': 1,
-            'lang': 'go', 'type': 'go_package', **meta,
-        }]
+    # Package-level chunk: always emitted, aggregates file path + all object names/descriptions
+    go_file = os.path.splitext(file_path)[0] + '.go'
+    pkg_lines = [f"package {package}", f"file: {os.path.basename(file_path)}", f"source: {os.path.basename(go_file)}"]
+    if meta['description']:
+        pkg_lines.append(meta['description'])
+    if objects:
+        pkg_lines.append("contains: " + ", ".join(o.get('name', '') for o in objects))
+        for obj in objects:
+            name = obj.get('name', '')
+            desc = str(obj.get('description', '')).strip()
+            if desc:
+                pkg_lines.append(f"{name}: {desc}")
+    chunks = [{
+        'text': '\n'.join(pkg_lines), 'file_path': file_path,
+        'section': package, 'start_line': 1, 'end_line': 1,
+        'lang': 'go', 'type': 'go_package', **meta,
+    }]
 
-    chunks = []
+    if not objects:
+        return chunks
+
     for i, obj in enumerate(objects):
         name     = obj.get('name', '')
         kind     = obj.get('kind', '')
@@ -197,14 +216,14 @@ def build_faiss_index(embeddings):
 
 def build_bm25_index(chunks):
     """Build BM25 index for lexical search."""
-    tokenized = [chunk['text'].lower().split() or [""] for chunk in chunks]
+    tokenized = [tokenize(chunk['text']) or [""] for chunk in chunks]
     return BM25Okapi(tokenized)
 
 def create_bm25_inverted_index(chunks, bm25):
     """Lightweight inverted index from BM25 scores (for SQLite compat)."""
     inverted_index = {}
     for i, chunk in enumerate(chunks):
-        tokens = set(chunk['text'].lower().split())
+        tokens = set(tokenize(chunk['text']))
         for word in tokens:
             score = float(bm25.get_scores([word])[i])
             if score > 0.01:
@@ -261,11 +280,12 @@ def create_knowledge_graph_with_content(chunks, embeddings):
     """Build knowledge graph using embedding cosine similarity + YAML related_nodes."""
     nodes, edges = [], []
 
-    # Build path -> [chunk_idx] index for related_nodes resolution
+    # Build path -> [chunk_id] index for related_nodes resolution
+    # Uses all file_paths (dedup-aware) so relative refs resolve from any repo copy
     path_to_chunk_ids = {}
     for chunk in chunks:
-        fp = chunk.get('file_path', '')
-        path_to_chunk_ids.setdefault(fp, []).append(chunk['id'])
+        for fp in chunk.get('file_paths', [chunk.get('file_path', '')]):
+            path_to_chunk_ids.setdefault(fp, []).append(chunk['id'])
 
     # Build chunk_id -> node_id index
     chunk_id_to_node_id = {}
@@ -312,6 +332,48 @@ def create_knowledge_graph_with_content(chunks, embeddings):
     for i, edge in enumerate(edges):
         edge['id'] = f'e{i+1}'
     return nodes, edges
+
+def _content_hash(text: str) -> str:
+    """Return SHA256 hex digest of normalized text content."""
+    return hashlib.sha256(text.strip().encode('utf-8')).hexdigest()
+
+
+def _dedup_chunks(chunks_list: list) -> list:
+    """Deduplicate chunks with identical content.
+
+    Chunks with the same text are merged into a single chunk:
+    - file_path  : canonical (first seen) path — kept for backward compat
+    - file_paths : list of ALL paths where this content appears
+    - tags / category / used_in / related_nodes : union of all occurrences
+    """
+    seen: dict[str, dict] = {}   # content_hash -> merged chunk
+    order: list[str] = []        # preserve first-seen order
+
+    for chunk in chunks_list:
+        h = _content_hash(chunk['text'])
+        if h not in seen:
+            merged = chunk.copy()
+            merged['file_paths'] = [chunk['file_path']]
+            seen[h] = merged
+            order.append(h)
+        else:
+            m = seen[h]
+            fp = chunk['file_path']
+            if fp not in m['file_paths']:
+                m['file_paths'].append(fp)
+            # union metadata fields
+            for field in ('tags', 'category', 'used_in', 'related_nodes'):
+                existing = set(m.get(field, []))
+                for v in chunk.get(field, []):
+                    existing.add(v)
+                m[field] = list(existing)
+
+    deduped = [seen[h] for h in order]
+    removed = len(chunks_list) - len(deduped)
+    if removed:
+        print(f"  [dedup] removed {removed} duplicate chunks ({len(deduped)} unique)")
+    return deduped
+
 
 def _is_go_meta_yaml(file_path):
     """Return True if the YAML file is a Go meta companion (has 'package' + 'objects').
@@ -364,6 +426,7 @@ def process_directory(directory_path):
 
 def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
     chunks_list = process_directory(source_directory)
+    chunks_list = _dedup_chunks(chunks_list)
     chunks_list.sort(key=lambda x: (x['file_path'], x['start_line']))
     for i, chunk in enumerate(chunks_list):
         chunk['id'] = f'c{i+1}'
@@ -391,7 +454,8 @@ def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
         if 'evidence_chunk_id' in edge:
             chunk = next((c for c in chunks_list if c['id'] == edge['evidence_chunk_id']), None)
             if chunk:
-                edge['evidence'] = [{'file': chunk['file_path'], 'start_line': chunk['start_line'], 'end_line': chunk['end_line']}]
+                edge['evidence'] = [{'file': fp, 'start_line': chunk['start_line'], 'end_line': chunk['end_line']}
+                                     for fp in chunk.get('file_paths', [chunk['file_path']])]
 
     return {
         "chunks": {item['id']: item for item in chunks_list},
@@ -469,14 +533,31 @@ def save_kb_to_sqlite(kb_data, output_dir="sqlite_data"):
         pk_str = f', PRIMARY KEY({", ".join(pk)})' if pk else ''
         cursor.execute(f"CREATE TABLE {table['name']} ({cols}{pk_str})")
 
-    files_map = {path: i + 1 for i, path in enumerate(sorted(list(set(c['file_path'] for c in kb_data['chunks'].values()))))}
+    # Collect all unique file paths (dedup-aware: file_paths list)
+    all_paths = sorted(set(
+        fp
+        for c in kb_data['chunks'].values()
+        for fp in c.get('file_paths', [c.get('file_path', '')])
+        if fp
+    ))
+    files_map = {path: i + 1 for i, path in enumerate(all_paths)}
     cursor.executemany("INSERT INTO files (id, path) VALUES (?, ?)", [(i, p) for p, i in files_map.items()])
 
     terms_map = {term: i + 1 for i, term in enumerate(sorted(kb_data['inverted_index'].keys()))}
     cursor.executemany("INSERT INTO terms (id, term) VALUES (?, ?)", [(i, t) for t, i in terms_map.items()])
 
-    chunk_data = [(c['id'], files_map[c['file_path']], c['text'], c['section'], c['start_line'], c['end_line'], c['lang'], c['type']) for c in kb_data['chunks'].values()]
-    cursor.executemany("INSERT INTO chunks VALUES (?, ?, ?, ?, ?, ?, ?, ?)", chunk_data)
+    # chunks table no longer has file_id (moved to chunk_paths junction table)
+    chunk_data = [(c['id'], c['text'], c['section'], c['start_line'], c['end_line'], c['lang'], c['type']) for c in kb_data['chunks'].values()]
+    cursor.executemany("INSERT INTO chunks VALUES (?, ?, ?, ?, ?, ?, ?)", chunk_data)
+
+    # chunk_paths: one row per (chunk_id, file_id) pair
+    chunk_paths_data = [
+        (c['id'], files_map[fp])
+        for c in kb_data['chunks'].values()
+        for fp in c.get('file_paths', [c.get('file_path', '')])
+        if fp and fp in files_map
+    ]
+    cursor.executemany("INSERT INTO chunk_paths (chunk_id, file_id) VALUES (?, ?)", chunk_paths_data)
 
     cursor.executemany("INSERT INTO nodes VALUES (?, ?, ?, ?)", [(n['id'], n['chunk_id'], n['type'], n['label']) for n in kb_data['nodes'].values()])
 

--- a/make_source.py
+++ b/make_source.py
@@ -201,7 +201,9 @@ def process_go_yaml(file_path):
             field_strs = [f"{f.get('name', '')} {f.get('type', '')}".strip() for f in fields]
             lines.append(f"fields: {', '.join(field_strs)}")
         if iface_methods:
-            lines.append(f"methods: {', '.join(m.get('name', '') for m in iface_methods)}")
+            # methods is a list of strings (method names)
+            method_names = [m if isinstance(m, str) else m.get('name', '') for m in iface_methods]
+            lines.append(f"methods: {', '.join(method_names)}")
 
         chunk = {
             'text': '\n'.join(lines),
@@ -212,6 +214,7 @@ def process_go_yaml(file_path):
             'lang': 'go',
             'type': f'go_{kind}' if kind else 'go_object',
             'calls': calls,
+            'implements': impl,
         }
         chunk.update(meta)
         chunks.append(chunk)
@@ -291,6 +294,7 @@ def process_py_yaml(file_path):
         if impl:
             lines.append(f"implements: {', '.join(impl)}")
 
+        py_calls = obj.get('calls', [])
         chunk = {
             'text': '\n'.join(lines),
             'file_path': file_path,
@@ -299,6 +303,8 @@ def process_py_yaml(file_path):
             'end_line': i + 1,
             'lang': 'python',
             'type': f'py_{kind}' if kind else 'py_object',
+            'calls': py_calls,
+            'implements': impl,
         }
         chunk.update(meta)
         chunks.append(chunk)
@@ -484,7 +490,7 @@ def create_knowledge_graph_with_content(chunks, embeddings):
 
     seen_calls: set = set()
     for chunk in chunks:
-        if chunk.get('lang') != 'go':
+        if chunk.get('lang') not in ('go', 'python'):
             continue
         src_node = chunk_id_to_node_id[chunk['id']]
         for call in chunk.get('calls', []):
@@ -497,6 +503,27 @@ def create_knowledge_graph_with_content(chunks, embeddings):
                         edge_id = f"e_{hashlib.md5((src_node + dst_node + 'calls').encode()).hexdigest()[:10]}"
                         edges.append({'id': edge_id, 'from': src_node, 'to': dst_node,
                                       'type': 'calls', 'weight': 1.0,
+                                      'evidence_chunk_id': chunk['id']})
+
+    # Implements edges: struct/class → interface
+    # Resolved by name across all indexed chunks.
+    iface_name_index: dict = {}
+    for chunk in chunks:
+        if chunk.get('type', '') in ('go_interface', 'py_class'):
+            iface_name_index.setdefault(chunk['section'], []).append(chunk_id_to_node_id[chunk['id']])
+
+    seen_impl: set = set()
+    for chunk in chunks:
+        src_node = chunk_id_to_node_id[chunk['id']]
+        for iface in chunk.get('implements', []):
+            for dst_node in iface_name_index.get(iface, []):
+                if dst_node != src_node:
+                    key = (src_node, dst_node)
+                    if key not in seen_impl:
+                        seen_impl.add(key)
+                        edge_id = f"e_{hashlib.md5((src_node + dst_node + 'implements').encode()).hexdigest()[:10]}"
+                        edges.append({'id': edge_id, 'from': src_node, 'to': dst_node,
+                                      'type': 'implements', 'weight': 1.0,
                                       'evidence_chunk_id': chunk['id']})
 
     return nodes, edges

--- a/make_source.py
+++ b/make_source.py
@@ -1,3 +1,4 @@
+
 import os
 import yaml
 import markdown
@@ -7,6 +8,7 @@ import pickle
 import sqlite3
 import re
 import hashlib
+import argparse
 import numpy as np
 from bs4 import BeautifulSoup
 from langdetect import detect, LangDetectException
@@ -15,6 +17,16 @@ from rank_bm25 import BM25Okapi
 import faiss
 
 EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "paraphrase-multilingual-MiniLM-L12-v2")
+
+# Directories to exclude from indexing
+EXCLUDE_DIRS = {
+    'p_venv', '.venv', 'venv',  # Python virtual environments
+    '.git', '.github',           # Git metadata
+    'node_modules', '.npm',      # Node.js
+    '.mcp_data',                 # Generated KB data
+    '__pycache__', '.pytest_cache', '.mypy_cache',  # Python caches
+    'dist', 'build', '.egg-info',  # Build artifacts
+}
 
 def tokenize(text):
     text = re.sub(r'([A-Z]+)([A-Z][a-z])', r'\1 \2', text)
@@ -336,16 +348,15 @@ def build_bm25_index(chunks):
     return BM25Okapi(tokenized)
 
 def create_bm25_inverted_index(chunks, bm25):
-    """Lightweight inverted index from BM25 scores (for SQLite compat)."""
+    """Build inverted index: word → chunk_ids (no score computation, deferred to query time)."""
     inverted_index = {}
-    for i, chunk in enumerate(chunks):
+    for chunk in chunks:
         tokens = set(tokenize(chunk['text']))
         for word in tokens:
-            score = float(bm25.get_scores([word])[i])
-            if score > 0.01:
-                inverted_index.setdefault(word, []).append({'chunk_id': chunk['id'], 'score': score})
+            inverted_index.setdefault(word, []).append(chunk['id'])
+    # Deduplicate
     for word in inverted_index:
-        inverted_index[word].sort(key=lambda x: x['score'], reverse=True)
+        inverted_index[word] = list(set(inverted_index[word]))
     return inverted_index
 
 def build_metadata_index(chunks):
@@ -403,11 +414,17 @@ def create_knowledge_graph_with_content(chunks, embeddings):
         for fp in chunk.get('file_paths', [chunk.get('file_path', '')]):
             path_to_chunk_ids.setdefault(fp, []).append(chunk['id'])
 
-    # Build chunk_id -> node_id index
+    # Build chunk_id -> node_id index (persistent node IDs based on chunk IDs)
     chunk_id_to_node_id = {}
-    for i, chunk in enumerate(chunks):
-        node_id = f"n{i + 1}"
+    for chunk in chunks:
+        # Node ID derived from chunk ID (persistent)
+        node_id = f"n_{chunk['id'][2:]}"  # strip 'c_' prefix, add 'n_' prefix
         chunk_id_to_node_id[chunk['id']] = node_id
+
+        # Detect test code: _test.go, _test.py, etc.
+        file_path = chunk.get('file_path', '')
+        is_test = '_test.' in file_path or '/tests/' in file_path or '/test/' in file_path
+
         nodes.append({
             'id': node_id,
             'chunk_id': chunk['id'],
@@ -417,23 +434,34 @@ def create_knowledge_graph_with_content(chunks, embeddings):
             'category': chunk.get('category', []),
             'used_in': chunk.get('used_in', []),
             'entrypoint': chunk.get('entrypoint', False),
+            'is_test': is_test,
         })
-        if i > 0:
-            edges.append({'from': f"n{i}", 'to': node_id, 'type': 'refers-to',
-                          'weight': 0.9, 'evidence_chunk_id': chunk['id']})
+
+    # Sequential refers-to edges (document order)
+    chunks_sorted_by_path = sorted(chunks, key=lambda c: (c['file_path'], c['start_line']))
+    for i in range(len(chunks_sorted_by_path) - 1):
+        src_chunk = chunks_sorted_by_path[i]
+        tgt_chunk = chunks_sorted_by_path[i + 1]
+        src_node = chunk_id_to_node_id[src_chunk['id']]
+        tgt_node = chunk_id_to_node_id[tgt_chunk['id']]
+        edge_id = f"e_{hashlib.md5((src_node + tgt_node + 'refers-to').encode()).hexdigest()[:10]}"
+        edges.append({'id': edge_id, 'from': src_node, 'to': tgt_node, 'type': 'refers-to',
+                      'weight': 0.9, 'evidence_chunk_id': src_chunk['id']})
 
     # Semantic edges from cosine similarity
-    cosine_sim = embeddings @ embeddings.T
-    for i in range(len(chunks)):
-        for j in range(i + 1, len(chunks)):
-            if cosine_sim[i, j] > 0.7:
-                edges.append({'from': f"n{i + 1}", 'to': f"n{j + 1}", 'type': 'related-to',
-                              'weight': float(cosine_sim[i, j]), 'evidence_chunk_id': chunks[i]['id']})
+    # SKIPPED: O(n²) memory bottleneck (4.8 GB matrix, SWAP thrashing)
+    # Alternative: Use PostgreSQL pgvector for semantic search
+    print("  [DEBUG] Skipping semantic edges (cosine similarity O(n²), use SQL instead)")
+    # cosine_sim = embeddings @ embeddings.T
+    # for i in range(len(chunks)):
+    #     for j in range(i + 1, len(chunks)):
+    #         if cosine_sim[i, j] > 0.7:
+    #             ...
 
     # Explicit reference edges from companion YAML related_nodes
     seen_refs = set()
-    for i, chunk in enumerate(chunks):
-        src_node = f"n{i + 1}"
+    for chunk in chunks:
+        src_node = chunk_id_to_node_id[chunk['id']]
         for rel_path in chunk.get('related_nodes', []):
             target_cids = _resolve_related_node(rel_path, chunk['file_path'], path_to_chunk_ids)
             for tcid in target_cids:
@@ -442,22 +470,23 @@ def create_knowledge_graph_with_content(chunks, embeddings):
                     key = (src_node, dst_node)
                     if key not in seen_refs:
                         seen_refs.add(key)
-                        edges.append({'from': src_node, 'to': dst_node, 'type': 'references',
+                        edge_id = f"e_{hashlib.md5((src_node + dst_node + 'references').encode()).hexdigest()[:10]}"
+                        edges.append({'id': edge_id, 'from': src_node, 'to': dst_node, 'type': 'references',
                                       'weight': 1.0, 'evidence_chunk_id': chunk['id']})
 
     # Call graph edges from AST calls lists.
     # Resolves internal calls by name within indexed Go chunks.
     # pkg.Name format: only the Name part is matched (pkg aliases can't be resolved cross-file).
     call_name_index: dict = {}
-    for i, chunk in enumerate(chunks):
+    for chunk in chunks:
         if chunk.get('lang') == 'go' and chunk.get('type', '').startswith('go_'):
-            call_name_index.setdefault(chunk['section'], []).append(f"n{i + 1}")
+            call_name_index.setdefault(chunk['section'], []).append(chunk_id_to_node_id[chunk['id']])
 
     seen_calls: set = set()
-    for i, chunk in enumerate(chunks):
+    for chunk in chunks:
         if chunk.get('lang') != 'go':
             continue
-        src_node = f"n{i + 1}"
+        src_node = chunk_id_to_node_id[chunk['id']]
         for call in chunk.get('calls', []):
             name = call.split('.')[-1] if '.' in call else call
             for dst_node in call_name_index.get(name, []):
@@ -465,12 +494,11 @@ def create_knowledge_graph_with_content(chunks, embeddings):
                     key = (src_node, dst_node)
                     if key not in seen_calls:
                         seen_calls.add(key)
-                        edges.append({'from': src_node, 'to': dst_node,
+                        edge_id = f"e_{hashlib.md5((src_node + dst_node + 'calls').encode()).hexdigest()[:10]}"
+                        edges.append({'id': edge_id, 'from': src_node, 'to': dst_node,
                                       'type': 'calls', 'weight': 1.0,
                                       'evidence_chunk_id': chunk['id']})
 
-    for i, edge in enumerate(edges):
-        edge['id'] = f'e{i+1}'
     return nodes, edges
 
 def _content_hash(text: str) -> str:
@@ -545,7 +573,9 @@ def process_directory(directory_path):
     go_companion_yamls = set()   # .yaml next to .go  → process via process_go_yaml
     py_companion_yamls = set()   # .yaml next to .py  → process via process_py_yaml
 
-    for root, _, files in os.walk(directory_path):
+    for root, dirs, files in os.walk(directory_path):
+        # In-place modify dirs to skip excluded directories
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
         for file in files:
             base = os.path.splitext(os.path.join(root, file))[0]
             if file.endswith('.md'):
@@ -562,7 +592,9 @@ def process_directory(directory_path):
                     py_companion_yamls.add(candidate)
 
     # Second pass: process files with correct handler
-    for root, _, files in os.walk(directory_path):
+    for root, dirs, files in os.walk(directory_path):
+        # In-place modify dirs to skip excluded directories
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
         for file in files:
             file_path = os.path.join(root, file)
             if file.endswith('.md'):
@@ -585,12 +617,32 @@ def process_directory(directory_path):
 
     return all_chunks
 
+def _generate_chunk_id(file_path: str, chunk_type: str, section: str, text: str = "") -> str:
+    """Generate persistent chunk ID based on file_path + type + section.
+
+    Ensures same chunk (same location, same type) gets same ID across builds,
+    enabling incremental updates without relabeling.
+    """
+    base = f"{file_path}:{chunk_type}:{section}"
+    if text:
+        base += f":{text[:100]}"  # include first 100 chars for extra collision avoidance
+    chunk_hash = hashlib.md5(base.encode('utf-8')).hexdigest()[:12]
+    return f"c_{chunk_hash}"
+
+
 def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
     chunks_list = process_directory(source_directory)
     chunks_list = _dedup_chunks(chunks_list)
     chunks_list.sort(key=lambda x: (x['file_path'], x['start_line']))
-    for i, chunk in enumerate(chunks_list):
-        chunk['id'] = f'c{i+1}'
+
+    # Generate persistent IDs based on file_path + type + section
+    for chunk in chunks_list:
+        chunk['id'] = _generate_chunk_id(
+            chunk['file_path'],
+            chunk['type'],
+            chunk.get('section', ''),
+            chunk.get('text', '')
+        )
 
     texts = [chunk['text'] for chunk in chunks_list]
 
@@ -604,7 +656,8 @@ def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
     faiss_index = build_faiss_index(embeddings)
 
     print("Building inverted index (BM25 scores for SQLite)...")
-    inverted_index = create_bm25_inverted_index(chunks_list, bm25)
+    print("  [DEBUG] Skipping inverted index (O(n*m) bottleneck, use SQL FTS instead)")
+    inverted_index = {}  # SKIP: SQL FTS will provide this functionality
 
     print("Building metadata index (tags/category/used_in)...")
     metadata_index = build_metadata_index(chunks_list)
@@ -618,6 +671,12 @@ def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
                 edge['evidence'] = [{'file': fp, 'start_line': chunk['start_line'], 'end_line': chunk['end_line']}
                                      for fp in chunk.get('file_paths', [chunk['file_path']])]
 
+    # Build embeddings_by_id dict for incremental updates (kb_watch.py)
+    embeddings_by_id = {
+        chunk['id']: embeddings[i].astype('float32')
+        for i, chunk in enumerate(chunks_list)
+    }
+
     return {
         "chunks": {item['id']: item for item in chunks_list},
         "nodes": {item['id']: item for item in nodes_list},
@@ -627,6 +686,7 @@ def build_knowledge_base(source_directory, model_name=EMBEDDING_MODEL):
         "bm25": bm25,
         "bm25_chunk_ids": [c['id'] for c in chunks_list],
         "faiss_index": faiss_index,
+        "embeddings_by_id": embeddings_by_id,
         "model_name": model_name,
     }
 
@@ -669,6 +729,11 @@ def save_knowledge_base_legacy(kb_data, output_dir="kb_data", save_json=True, sa
         if bm25_chunk_ids is not None:
             with open(os.path.join(output_dir, 'pkl', 'chunk_ids.pkl'), 'wb') as f:
                 pickle.dump(bm25_chunk_ids, f)
+
+        embeddings_by_id = kb_data.get("embeddings_by_id", {})
+        if embeddings_by_id:
+            with open(os.path.join(output_dir, 'pkl', 'embeddings_by_id.pkl'), 'wb') as f:
+                pickle.dump(embeddings_by_id, f)
 
         with open(os.path.join(output_dir, 'pkl', 'model_name.pkl'), 'wb') as f:
             pickle.dump(kb_data.get("model_name", EMBEDDING_MODEL), f)
@@ -775,16 +840,50 @@ def generate_edge_types_doc(kb_data, output_dir="kb_data"):
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Build knowledge base from source directory")
+    parser.add_argument(
+        "--source",
+        default=os.environ.get("SOURCE_DIR", "./source"),
+        help="Source directory path (default: env SOURCE_DIR or ./source)"
+    )
+    parser.add_argument(
+        "--output-kb",
+        default=os.environ.get("KB_OUTPUT_DIR", "./kb_data"),
+        help="Output directory for knowledge base artifacts (default: env KB_OUTPUT_DIR or ./kb_data)"
+    )
+    parser.add_argument(
+        "--output-sqlite",
+        default=os.environ.get("SQLITE_OUTPUT_DIR", "./sqlite_data"),
+        help="Output directory for SQLite database (default: env SQLITE_OUTPUT_DIR or ./sqlite_data)"
+    )
+    parser.add_argument(
+        "--output-formats",
+        default=os.environ.get("KB_OUTPUT_FORMATS", "pkl,json,sqlite"),
+        help="Output formats as comma-separated list: pkl,json,sqlite (default: all, env: KB_OUTPUT_FORMATS)"
+    )
+    args = parser.parse_args()
+
+    # Parse output formats
+    formats = set(f.strip().lower() for f in args.output_formats.split(','))
+    save_pkl = 'pkl' in formats
+    save_json = 'json' in formats
+    save_sqlite = 'sqlite' in formats
+
     print("Starting knowledge base generation...")
-    source_path = './source'
-    legacy_output_path = './kb_data'
-    sqlite_output_path = './sqlite_data'
+    print(f"Output formats: {', '.join(sorted(formats))}")
+    source_path = args.source
+    legacy_output_path = args.output_kb
+    sqlite_output_path = args.output_sqlite
 
     kb_objects = build_knowledge_base(source_path)
 
-    save_knowledge_base_legacy(kb_objects, output_dir=legacy_output_path, save_json=True, save_pickle=True)
-    save_kb_to_sqlite(kb_objects, output_dir=sqlite_output_path)
-    generate_edge_types_doc(kb_objects, output_dir=legacy_output_path)
+    if save_pkl or save_json:
+        save_knowledge_base_legacy(kb_objects, output_dir=legacy_output_path, save_json=save_json, save_pickle=save_pkl)
+        if save_pkl or save_json:
+            generate_edge_types_doc(kb_objects, output_dir=legacy_output_path)
+
+    if save_sqlite:
+        save_kb_to_sqlite(kb_objects, output_dir=sqlite_output_path)
 
     print("\n--- Generation Complete ---")
     print(f"Total chunks: {len(kb_objects['chunks'])}")
@@ -797,8 +896,9 @@ if __name__ == "__main__":
     print(f"Unique used_in: {len(meta.get('used_in_index', {}))}")
     print(f"Entrypoints: {len(meta.get('entrypoint_ids', []))}")
 
-    print(f"\nSuccessfully created legacy data files in '{legacy_output_path}/'")
-    print(f"Successfully created SQLite DB in '{sqlite_output_path}/'")
-
-    db_size = os.path.getsize(os.path.join(sqlite_output_path, 'knowledge_base.sqlite'))
-    print(f"SQLite database size: {db_size / 1024 / 1024:.2f} MB")
+    if save_pkl or save_json:
+        print(f"\nSuccessfully created legacy data files in '{legacy_output_path}/'")
+    if save_sqlite:
+        print(f"Successfully created SQLite DB in '{sqlite_output_path}/'")
+        db_size = os.path.getsize(os.path.join(sqlite_output_path, 'knowledge_base.sqlite'))
+        print(f"SQLite database size: {db_size / 1024 / 1024:.2f} MB")

--- a/make_source.py
+++ b/make_source.py
@@ -354,15 +354,21 @@ def build_bm25_index(chunks):
     return BM25Okapi(tokenized)
 
 def create_bm25_inverted_index(chunks, bm25):
-    """Build inverted index: word → chunk_ids (no score computation, deferred to query time)."""
-    inverted_index = {}
+    """Build inverted index: word → [{chunk_id, score}, ...] sorted by score desc."""
+    vocab: set = set()
     for chunk in chunks:
-        tokens = set(tokenize(chunk['text']))
-        for word in tokens:
-            inverted_index.setdefault(word, []).append(chunk['id'])
-    # Deduplicate
-    for word in inverted_index:
-        inverted_index[word] = list(set(inverted_index[word]))
+        vocab.update(tokenize(chunk['text']))
+    inverted_index = {}
+    for word in vocab:
+        scores = bm25.get_scores([word])
+        entries = [
+            {'chunk_id': chunks[i]['id'], 'score': float(scores[i])}
+            for i in range(len(chunks))
+            if scores[i] > 0
+        ]
+        if entries:
+            entries.sort(key=lambda e: e['score'], reverse=True)
+            inverted_index[word] = entries
     return inverted_index
 
 def build_metadata_index(chunks):
@@ -423,9 +429,15 @@ def create_knowledge_graph_with_content(chunks, embeddings):
     # Build chunk_id -> node_id index (persistent node IDs based on chunk IDs)
     chunk_id_to_node_id = {}
     for chunk in chunks:
-        # Node ID derived from chunk ID (persistent)
-        node_id = f"n_{chunk['id'][2:]}"  # strip 'c_' prefix, add 'n_' prefix
-        chunk_id_to_node_id[chunk['id']] = node_id
+        cid = chunk['id']
+        # Production IDs: 'c_xxxxxxxx' → strip 'c_' → 'n_xxxxxxxx'
+        # Short test IDs: 'c1' → hash → 'n_<hash>'
+        if cid.startswith('c_') and len(cid) > 2:
+            suffix = cid[2:]
+        else:
+            suffix = hashlib.md5(cid.encode()).hexdigest()[:10]
+        node_id = f"n_{suffix}"
+        chunk_id_to_node_id[cid] = node_id
 
         # Detect test code: _test.go, _test.py, etc.
         file_path = chunk.get('file_path', '')

--- a/make_source.py
+++ b/make_source.py
@@ -145,32 +145,61 @@ def process_go_yaml(file_path):
     if not objects:
         return chunks
 
-    for i, obj in enumerate(objects):
-        name     = obj.get('name', '')
-        kind     = obj.get('kind', '')
-        receiver = obj.get('receiver', '')
-        desc     = str(obj.get('description', '')).strip()
-        refs     = obj.get('references', [])
-        impl     = obj.get('implements', [])
+    for obj in objects:
+        name          = obj.get('name', '')
+        kind          = obj.get('kind', '')
+        receiver      = obj.get('receiver', '')
+        desc          = str(obj.get('description', '')).strip()
+        refs          = obj.get('references', [])
+        impl          = obj.get('implements', [])
+        position      = obj.get('position', {})
+        signature     = obj.get('signature', {})
+        calls         = obj.get('calls', [])
+        fields        = obj.get('fields', [])
+        iface_methods = obj.get('methods', [])
 
-        # Build searchable text: signature + description + references
-        sig = f"method ({receiver}) {name}" if receiver else f"{kind} {name}"
-        lines = [sig]
+        sig_str = ''
+        if signature:
+            params = ', '.join(
+                f"{p.get('name', '')} {p.get('type', '')}".strip()
+                for p in signature.get('params', [])
+            )
+            returns = ', '.join(signature.get('returns', []))
+            sig_str = f"({params})"
+            if returns:
+                sig_str += f" {returns}"
+
+        if receiver:
+            sig_line = f"method ({receiver}) {name}{sig_str}"
+        elif kind in ('func',):
+            sig_line = f"func {name}{sig_str}"
+        else:
+            sig_line = f"{kind} {name}"
+
+        lines = [sig_line]
         if desc:
             lines.append(desc)
         if refs:
             lines.append(f"references: {', '.join(refs)}")
         if impl:
             lines.append(f"implements: {', '.join(impl)}")
+        if calls:
+            lines.append(f"calls: {', '.join(calls)}")
+        if fields:
+            field_strs = [f"{f.get('name', '')} {f.get('type', '')}".strip() for f in fields]
+            lines.append(f"fields: {', '.join(field_strs)}")
+        if iface_methods:
+            lines.append(f"methods: {', '.join(m.get('name', '') for m in iface_methods)}")
 
         chunk = {
             'text': '\n'.join(lines),
             'file_path': file_path,
             'section': name,
-            'start_line': i + 1,
-            'end_line': i + 1,
+            'start_line': position.get('start_line', 1),
+            'end_line':   position.get('end_line', 1),
             'lang': 'go',
             'type': f'go_{kind}' if kind else 'go_object',
+            'calls': calls,
         }
         chunk.update(meta)
         chunks.append(chunk)
@@ -415,6 +444,30 @@ def create_knowledge_graph_with_content(chunks, embeddings):
                         seen_refs.add(key)
                         edges.append({'from': src_node, 'to': dst_node, 'type': 'references',
                                       'weight': 1.0, 'evidence_chunk_id': chunk['id']})
+
+    # Call graph edges from AST calls lists.
+    # Resolves internal calls by name within indexed Go chunks.
+    # pkg.Name format: only the Name part is matched (pkg aliases can't be resolved cross-file).
+    call_name_index: dict = {}
+    for i, chunk in enumerate(chunks):
+        if chunk.get('lang') == 'go' and chunk.get('type', '').startswith('go_'):
+            call_name_index.setdefault(chunk['section'], []).append(f"n{i + 1}")
+
+    seen_calls: set = set()
+    for i, chunk in enumerate(chunks):
+        if chunk.get('lang') != 'go':
+            continue
+        src_node = f"n{i + 1}"
+        for call in chunk.get('calls', []):
+            name = call.split('.')[-1] if '.' in call else call
+            for dst_node in call_name_index.get(name, []):
+                if dst_node != src_node:
+                    key = (src_node, dst_node)
+                    if key not in seen_calls:
+                        seen_calls.add(key)
+                        edges.append({'from': src_node, 'to': dst_node,
+                                      'type': 'calls', 'weight': 1.0,
+                                      'evidence_chunk_id': chunk['id']})
 
     for i, edge in enumerate(edges):
         edge['id'] = f'e{i+1}'

--- a/make_source.yaml
+++ b/make_source.yaml
@@ -1,0 +1,149 @@
+---
+module: make_source
+description: ''
+tags:
+- builder
+- core
+- loader
+- storage
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: EMBEDDING_MODEL
+  kind: const
+  description: ''
+  references: []
+- name: tokenize
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: detect_language
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - langdetect.LangDetectException
+  - langdetect.detect
+- name: load_companion_yaml
+  kind: function
+  decorators: []
+  description: Load a companion .yaml file for an .md file if it exists.
+  references:
+  - yaml.YAMLError
+  - yaml.safe_load
+- name: _normalize_list
+  kind: function
+  decorators: []
+  description: Normalize a YAML value to a list of strings.
+  references: []
+- name: process_md_file
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: process_go_yaml
+  kind: function
+  decorators: []
+  description: Process a .go.yaml companion file as structured knowledge chunks. The
+    .go source file is not indexed (code excluded by design); this YAML is the sole
+    knowledge source for Go files in the KB. Produces one chunk per object defined
+    in the file. File-level metadata (tags, category, used_in) is applied to all chunks.
+  references:
+  - yaml.YAMLError
+  - yaml.safe_load
+- name: process_yaml_file
+  kind: function
+  decorators: []
+  description: Processes a YAML file as a single, large chunk to preserve context.
+  references:
+  - yaml.YAMLError
+  - yaml.dump
+  - yaml.safe_load
+- name: create_embeddings
+  kind: function
+  decorators: []
+  description: Encode texts using a multilingual sentence transformer model.
+  references:
+  - numpy.array
+  - sentence_transformers.SentenceTransformer
+- name: build_faiss_index
+  kind: function
+  decorators: []
+  description: Build FAISS inner-product index (cosine sim with normalized vectors).
+  references:
+  - faiss.IndexFlatIP
+- name: build_bm25_index
+  kind: function
+  decorators: []
+  description: Build BM25 index for lexical search.
+  references:
+  - rank_bm25.BM25Okapi
+- name: create_bm25_inverted_index
+  kind: function
+  decorators: []
+  description: Lightweight inverted index from BM25 scores (for SQLite compat).
+  references: []
+- name: build_metadata_index
+  kind: function
+  decorators: []
+  description: Build O(1) lookup indexes for tags, category, used_in, entrypoints.
+  references: []
+- name: _resolve_related_node
+  kind: function
+  decorators: []
+  description: Resolve a relative related_node path to chunk_ids.
+  references: []
+- name: create_knowledge_graph_with_content
+  kind: function
+  decorators: []
+  description: Build knowledge graph using embedding cosine similarity + YAML related_nodes.
+  references: []
+- name: _content_hash
+  kind: function
+  decorators: []
+  description: Return SHA256 hex digest of normalized text content.
+  references: []
+- name: _dedup_chunks
+  kind: function
+  decorators: []
+  description: 'Deduplicate chunks with identical content. Chunks with the same text
+    are merged into a single chunk: - file_path  : canonical (first seen) path — kept
+    for backward compat - file_paths : list of ALL paths where this content appears
+    - tags / category / used_in / related_nodes : union of all occurrences'
+  references: []
+- name: _is_go_meta_yaml
+  kind: function
+  decorators: []
+  description: Return True if the YAML file is a Go meta companion (has 'package'
+    + 'objects'). Used when the sibling .go file is absent (e.g. in docs-only submodules).
+  references:
+  - yaml.safe_load
+- name: process_directory
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: build_knowledge_base
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: save_knowledge_base_legacy
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - faiss.write_index
+- name: save_kb_to_sqlite
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: generate_edge_types_doc
+  kind: function
+  decorators: []
+  description: Generates a markdown file documenting all unique edge types.
+  references: []

--- a/make_source.yaml
+++ b/make_source.yaml
@@ -15,17 +15,26 @@ objects:
   kind: const
   description: ''
   references: []
+- name: EXCLUDE_DIRS
+  kind: const
+  description: ''
+  references: []
 - name: tokenize
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - t.strip
+  - text.lower
 - name: detect_language
   kind: function
   decorators: []
   description: ''
   references:
   - langdetect.LangDetectException
+  - langdetect.detect
+  calls:
   - langdetect.detect
 - name: load_companion_yaml
   kind: function
@@ -34,16 +43,27 @@ objects:
   references:
   - yaml.YAMLError
   - yaml.safe_load
+  calls:
+  - yaml.safe_load
 - name: _normalize_list
   kind: function
   decorators: []
   description: Normalize a YAML value to a list of strings.
   references: []
+  calls: []
 - name: process_md_file
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _normalize_list
+  - chunk.update
+  - chunks.append
+  - companion.get
+  - current_chunk_lines.append
+  - f.readlines
+  - match.group
 - name: process_go_yaml
   kind: function
   decorators: []
@@ -54,12 +74,52 @@ objects:
   references:
   - yaml.YAMLError
   - yaml.safe_load
+  calls:
+  - _normalize_list
+  - chunk.update
+  - chunks.append
+  - data.get
+  - f.get
+  - lines.append
+  - m.get
+  - o.get
+  - obj.get
+  - p.get
+  - pkg_lines.append
+  - position.get
+  - signature.get
+  - yaml.safe_load
+- name: process_py_yaml
+  kind: function
+  decorators: []
+  description: 'Process a .py.yaml companion file as structured knowledge chunks.
+    Mirrors process_go_yaml: the .py source file is not indexed directly (code excluded
+    by design); this YAML is the sole knowledge source for Python files in the KB.
+    Produces one chunk per object defined in the file. File-level metadata (tags,
+    category, used_in) is applied to all chunks.'
+  references:
+  - yaml.YAMLError
+  - yaml.safe_load
+  calls:
+  - _normalize_list
+  - chunk.update
+  - chunks.append
+  - data.get
+  - lines.append
+  - mod_lines.append
+  - o.get
+  - obj.get
+  - yaml.safe_load
 - name: process_yaml_file
   kind: function
   decorators: []
   description: Processes a YAML file as a single, large chunk to preserve context.
   references:
   - yaml.YAMLError
+  - yaml.dump
+  - yaml.safe_load
+  calls:
+  - text_content.splitlines
   - yaml.dump
   - yaml.safe_load
 - name: create_embeddings
@@ -69,43 +129,77 @@ objects:
   references:
   - numpy.array
   - sentence_transformers.SentenceTransformer
+  calls:
+  - model.encode
+  - numpy.array
+  - sentence_transformers.SentenceTransformer
 - name: build_faiss_index
   kind: function
   decorators: []
   description: Build FAISS inner-product index (cosine sim with normalized vectors).
   references:
   - faiss.IndexFlatIP
+  calls:
+  - faiss.IndexFlatIP
+  - index.add
 - name: build_bm25_index
   kind: function
   decorators: []
   description: Build BM25 index for lexical search.
   references:
   - rank_bm25.BM25Okapi
+  calls:
+  - rank_bm25.BM25Okapi
 - name: create_bm25_inverted_index
   kind: function
   decorators: []
-  description: Lightweight inverted index from BM25 scores (for SQLite compat).
+  description: 'Build inverted index: word → chunk_ids (no score computation, deferred
+    to query time).'
   references: []
+  calls:
+  - inverted_index.setdefault
 - name: build_metadata_index
   kind: function
   decorators: []
   description: Build O(1) lookup indexes for tags, category, used_in, entrypoints.
   references: []
+  calls:
+  - category_index.setdefault
+  - chunk.get
+  - entrypoint_ids.append
+  - tag_index.setdefault
+  - used_in_index.setdefault
 - name: _resolve_related_node
   kind: function
   decorators: []
   description: Resolve a relative related_node path to chunk_ids.
   references: []
+  calls:
+  - path_to_chunk_ids.items
 - name: create_knowledge_graph_with_content
   kind: function
   decorators: []
   description: Build knowledge graph using embedding cosine similarity + YAML related_nodes.
   references: []
+  calls:
+  - _resolve_related_node
+  - call.split
+  - call_name_index.get
+  - call_name_index.setdefault
+  - chunk.get
+  - chunk_id_to_node_id.get
+  - edges.append
+  - nodes.append
+  - path_to_chunk_ids.setdefault
+  - seen_calls.add
+  - seen_refs.add
 - name: _content_hash
   kind: function
   decorators: []
   description: Return SHA256 hex digest of normalized text content.
   references: []
+  calls:
+  - text.strip
 - name: _dedup_chunks
   kind: function
   decorators: []
@@ -114,6 +208,13 @@ objects:
     for backward compat - file_paths : list of ALL paths where this content appears
     - tags / category / used_in / related_nodes : union of all occurrences'
   references: []
+  calls:
+  - _content_hash
+  - chunk.copy
+  - chunk.get
+  - existing.add
+  - m.get
+  - order.append
 - name: _is_go_meta_yaml
   kind: function
   decorators: []
@@ -121,29 +222,82 @@ objects:
     + 'objects'). Used when the sibling .go file is absent (e.g. in docs-only submodules).
   references:
   - yaml.safe_load
+  calls:
+  - yaml.safe_load
+- name: _is_py_meta_yaml
+  kind: function
+  decorators: []
+  description: Return True if the YAML file is a Python meta companion (has 'module'
+    + 'objects'). Used when the sibling .py file is absent (e.g. in docs-only submodules).
+  references:
+  - yaml.safe_load
+  calls:
+  - yaml.safe_load
 - name: process_directory
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _is_go_meta_yaml
+  - _is_py_meta_yaml
+  - all_chunks.extend
+  - file.endswith
+  - go_companion_yamls.add
+  - md_companion_yamls.add
+  - py_companion_yamls.add
+- name: _generate_chunk_id
+  kind: function
+  decorators: []
+  description: Generate persistent chunk ID based on file_path + type + section. Ensures
+    same chunk (same location, same type) gets same ID across builds, enabling incremental
+    updates without relabeling.
+  references: []
+  calls:
+  - base.encode
 - name: build_knowledge_base
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _dedup_chunks
+  - _generate_chunk_id
+  - chunk.get
+  - chunks_list.sort
 - name: save_knowledge_base_legacy
   kind: function
   decorators: []
   description: ''
   references:
   - faiss.write_index
+  calls:
+  - faiss.write_index
+  - kb_data.get
+  - legacy_data.items
 - name: save_kb_to_sqlite
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - c.get
+  - conn.close
+  - conn.commit
+  - conn.cursor
+  - cursor.execute
+  - cursor.executemany
+  - e.get
+  - files_map.items
+  - inverted_index_data.append
+  - kb_data.get
+  - table.get
+  - terms_map.get
+  - terms_map.items
 - name: generate_edge_types_doc
   kind: function
   decorators: []
   description: Generates a markdown file documenting all unique edge types.
   references: []
+  calls:
+  - f.write

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,3 @@
+# MCP Server for Knowledge Base
+
+This directory contains the MCP server implementation that exposes the knowledge base to AI assistants.

--- a/mcp-server/kb_watch.py
+++ b/mcp-server/kb_watch.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+kb_watch.py — Incremental KB updater for development use.
+
+Watches any directory for file changes and keeps the knowledge base PKLs
+up-to-date without a full rebuild.  Only newly changed files are re-processed;
+existing embeddings are reused from the sidecar `embeddings_by_id.pkl`.
+
+Works with any repo or directory — not MCP-specific.
+
+Usage:
+    python mcp-server/kb_watch.py <watch_dir> [--kb-dir kb_data] [--interval 2]
+    python mcp-server/kb_watch.py <watch_dir> --once    # single scan + exit
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import pickle
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# make_source lives one level up (next to mcp-server/)
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import make_source  # noqa: E402
+
+
+# ── file-state tracking ─────────────────────────────────────────────────────
+
+_STATE_FILE = '.file_state.json'
+_WATCHED_EXTS = ('.md', '.yaml', '.yml')
+
+
+def _file_hash(path: str) -> str:
+    try:
+        with open(path, 'rb') as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        return ''
+
+
+def load_file_state(kb_dir: Path) -> dict:
+    p = kb_dir / _STATE_FILE
+    if p.exists():
+        try:
+            return json.loads(p.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def save_file_state(kb_dir: Path, state: dict) -> None:
+    (kb_dir / _STATE_FILE).write_text(json.dumps(state, indent=2))
+
+
+def scan_directory(watch_dir: Path) -> dict:
+    """Return {abs_path_str: content_hash} for all processable files."""
+    result = {}
+    for root, _, files in os.walk(watch_dir):
+        for fname in files:
+            if any(fname.endswith(e) for e in _WATCHED_EXTS) and not fname.startswith('.'):
+                p = os.path.join(root, fname)
+                result[p] = _file_hash(p)
+    return result
+
+
+def diff_state(watch_dir: Path, old_state: dict) -> tuple[list, list, dict]:
+    """Return (changed_or_new, deleted, current_scan)."""
+    current = scan_directory(watch_dir)
+    changed = [p for p, h in current.items() if old_state.get(p) != h]
+    deleted = [p for p in old_state if p not in current]
+    return changed, deleted, current
+
+
+# ── single-file processor dispatch ─────────────────────────────────────────
+
+def _classify_yaml(file_path: str) -> str:
+    """Determine which processor handles this YAML: 'go' | 'py' | 'md' | 'generic'."""
+    base = os.path.splitext(file_path)[0]
+    if os.path.exists(base + '.go'):
+        return 'go'
+    if os.path.exists(base + '.py'):
+        return 'py'
+    if os.path.exists(base + '.md'):
+        return 'md'
+    if make_source._is_go_meta_yaml(file_path):
+        return 'go'
+    if make_source._is_py_meta_yaml(file_path):
+        return 'py'
+    return 'generic'
+
+
+def process_file(file_path: str) -> list:
+    """Route a single file to the correct make_source processor."""
+    if file_path.endswith('.md'):
+        return make_source.process_md_file(file_path)
+    if file_path.endswith(('.yaml', '.yml')):
+        kind = _classify_yaml(file_path)
+        if kind == 'go':
+            return make_source.process_go_yaml(file_path)
+        if kind == 'py':
+            return make_source.process_py_yaml(file_path)
+        if kind == 'md':
+            return []  # companion YAML — content included via .md handler
+        return make_source.process_yaml_file(file_path)
+    return []
+
+
+# ── PKL helpers ──────────────────────────────────────────────────────────────
+
+def _pkl_path(kb_dir: Path, name: str) -> Path:
+    return kb_dir / 'pkl' / name
+
+
+def _load_pkl(kb_dir: Path, name: str, default):
+    p = _pkl_path(kb_dir, name)
+    if p.exists():
+        with p.open('rb') as f:
+            return pickle.load(f)
+    return default
+
+
+def _dump_pkl(kb_dir: Path, name: str, obj) -> None:
+    _pkl_path(kb_dir, name).write_bytes(pickle.dumps(obj))
+
+
+def _load_chunks(kb_dir: Path) -> dict:
+    """Load chunks.pkl and normalize to dict[chunk_id, chunk_dict]."""
+    raw = _load_pkl(kb_dir, 'chunks.pkl', {})
+    if isinstance(raw, list):
+        return {c['id']: c for c in raw if isinstance(c, dict) and 'id' in c}
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
+# ── incremental update ────────────────────────────────────────────────────
+
+def _chunks_for_files(chunks_by_id: dict, file_paths: list) -> set:
+    fp_set = set(file_paths)
+    return {
+        cid for cid, c in chunks_by_id.items()
+        if fp_set & set(c.get('file_paths', [c.get('file_path', '')]))
+    }
+
+
+def _next_chunk_id(chunks_by_id: dict) -> int:
+    nums = [int(cid[1:]) for cid in chunks_by_id if cid.startswith('c') and cid[1:].isdigit()]
+    return max(nums, default=0) + 1
+
+
+def incremental_update(watch_dir: Path, changed: list, deleted: list,
+                       kb_dir: Path, model) -> dict:
+    """
+    Process changed/deleted files and update KB PKLs in-place.
+
+    Returns a summary dict: {removed, added, total}.
+    """
+    # ── load ──────────────────────────────────────────────────────────────
+    chunks_by_id: dict = _load_chunks(kb_dir)
+    embeddings_by_id: dict = _load_pkl(kb_dir, 'embeddings_by_id.pkl', {})
+
+    # ── remove stale chunks (changed files will be re-added below) ────────
+    stale_ids = _chunks_for_files(chunks_by_id, changed + deleted)
+    for cid in stale_ids:
+        chunks_by_id.pop(cid, None)
+        embeddings_by_id.pop(cid, None)
+
+    # ── reprocess changed files ───────────────────────────────────────────
+    new_chunks: list = []
+    for fp in changed:
+        try:
+            fc = process_file(fp)
+            new_chunks.extend(fc)
+        except Exception as exc:
+            print(f"  [warn] {os.path.basename(fp)}: {exc}")
+
+    # assign IDs continuing from current max
+    next_id = _next_chunk_id(chunks_by_id)
+    for i, chunk in enumerate(new_chunks):
+        chunk['id'] = f'c{next_id + i}'
+        chunk.setdefault('file_paths', [chunk.get('file_path', '')])
+
+    # ── embed only new chunks ─────────────────────────────────────────────
+    if new_chunks:
+        texts = [c.get('text', '') for c in new_chunks]
+        vecs = model.encode(texts, normalize_embeddings=True, batch_size=32, show_progress_bar=False)
+        for chunk, vec in zip(new_chunks, vecs):
+            chunks_by_id[chunk['id']] = chunk
+            embeddings_by_id[chunk['id']] = vec.astype('float32')
+
+    # ── rebuild FAISS from ALL current embeddings (no re-encoding) ────────
+    try:
+        import faiss as _faiss
+        if embeddings_by_id:
+            id_order = list(embeddings_by_id.keys())
+            mat = np.stack([embeddings_by_id[cid] for cid in id_order]).astype('float32')
+            faiss_idx = _faiss.IndexFlatIP(mat.shape[1])
+            faiss_idx.add(mat)
+            _faiss.write_index(faiss_idx, str(_pkl_path(kb_dir, 'faiss.index')))
+    except ImportError:
+        pass
+
+    # ── rebuild BM25 + inverted index from ALL current chunks ─────────────
+    # BM25 is fast (tokenization only, no encoding) — gives correct IDF scores
+    all_chunks = list(chunks_by_id.values())
+    if all_chunks:
+        bm25 = make_source.build_bm25_index(all_chunks)
+        inv_index = make_source.create_bm25_inverted_index(all_chunks, bm25)
+        _dump_pkl(kb_dir, 'bm25.pkl', bm25)
+        _dump_pkl(kb_dir, 'chunk_ids.pkl', [c['id'] for c in all_chunks])
+    else:
+        inv_index = {}
+
+    # ── persist ────────────────────────────────────────────────────────────
+    _dump_pkl(kb_dir, 'chunks.pkl', chunks_by_id)
+    _dump_pkl(kb_dir, 'embeddings_by_id.pkl', embeddings_by_id)
+    _dump_pkl(kb_dir, 'inverted_index.pkl', inv_index)
+
+    return {'removed': len(stale_ids), 'added': len(new_chunks), 'total': len(chunks_by_id)}
+
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+def _load_model(kb_dir: Path):
+    from sentence_transformers import SentenceTransformer
+    model_name = _load_pkl(kb_dir, 'model_name.pkl', make_source.EMBEDDING_MODEL)
+    print(f"Loading model: {model_name}")
+    return SentenceTransformer(model_name)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description='Incremental KB watcher — watches any directory, updates KB PKLs on file change',
+    )
+    ap.add_argument('watch_dir', help='Directory to watch')
+    ap.add_argument('--kb-dir', default='kb_data', help='KB output directory (default: kb_data)')
+    ap.add_argument('--interval', type=float, default=2.0, help='Poll interval in seconds (default: 2)')
+    ap.add_argument('--once', action='store_true', help='Single scan then exit')
+    args = ap.parse_args()
+
+    watch_dir = Path(args.watch_dir).resolve()
+    kb_dir = Path(args.kb_dir).resolve()
+    (kb_dir / 'pkl').mkdir(parents=True, exist_ok=True)
+
+    model = _load_model(kb_dir)
+    file_state = load_file_state(kb_dir)
+
+    if args.once:
+        changed, deleted, current = diff_state(watch_dir, file_state)
+        if changed or deleted:
+            s = incremental_update(watch_dir, changed, deleted, kb_dir, model)
+            save_file_state(kb_dir, current)
+            print(f"removed={s['removed']} added={s['added']} total={s['total']}")
+        else:
+            print("No changes.")
+        return
+
+    print(f"Watching {watch_dir}")
+    print(f"KB:       {kb_dir}  (interval: {args.interval}s — Ctrl-C to stop)")
+    try:
+        while True:
+            changed, deleted, current = diff_state(watch_dir, file_state)
+            if changed or deleted:
+                ts = time.strftime('%H:%M:%S')
+                print(f"\n[{ts}] {len(changed)} changed, {len(deleted)} deleted")
+                for fp in changed:
+                    print(f"  ~ {os.path.relpath(fp, watch_dir)}")
+                for fp in deleted:
+                    print(f"  - {os.path.relpath(fp, watch_dir)}")
+                s = incremental_update(watch_dir, changed, deleted, kb_dir, model)
+                file_state = current
+                save_file_state(kb_dir, file_state)
+                print(f"  → removed={s['removed']} added={s['added']} total={s['total']}")
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        print("\nStopped.")
+
+
+if __name__ == '__main__':
+    main()

--- a/mcp-server/kb_watch.py
+++ b/mcp-server/kb_watch.py
@@ -18,21 +18,41 @@ import hashlib
 import json
 import os
 import pickle
+import subprocess
 import sys
 import time
 from pathlib import Path
 
 import numpy as np
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
 
 # make_source lives one level up (next to mcp-server/)
 sys.path.insert(0, str(Path(__file__).parent.parent))
 import make_source  # noqa: E402
+from make_source import _generate_chunk_id  # noqa: E402
 
 
 # ── file-state tracking ─────────────────────────────────────────────────────
 
 _STATE_FILE = '.file_state.json'
-_WATCHED_EXTS = ('.md', '.yaml', '.yml')
+_WATCHED_EXTS = ('.md', '.yaml', '.yml', '.go', '.py')
+
+# Generator config: file types that need companion YAML generated
+_GENERATORS = {
+    '.go': 'go.meta.gen.py',
+    '.py': 'py.meta.gen.py',
+}
+
+# Directories to exclude from indexing
+_EXCLUDE_DIRS = {
+    'p_venv', '.venv', 'venv',  # Python virtual environments
+    '.git', '.github',           # Git metadata
+    'node_modules', '.npm',      # Node.js
+    '.mcp_data',                 # Generated KB data
+    '__pycache__', '.pytest_cache', '.mypy_cache',  # Python caches
+    'dist', 'build', '.egg-info',  # Build artifacts
+}
 
 
 def _file_hash(path: str) -> str:
@@ -57,10 +77,26 @@ def save_file_state(kb_dir: Path, state: dict) -> None:
     (kb_dir / _STATE_FILE).write_text(json.dumps(state, indent=2))
 
 
+def save_manifest(kb_dir: Path, status: dict) -> None:
+    """Write kb_manifest.json with index version info."""
+    manifest = {
+        "timestamp": time.time(),
+        "chunks_mtime": status.get("chunks_mtime", 0),
+        "search_mtime": status.get("search_mtime", 0),
+        "graph_mtime": status.get("graph_mtime", 0),
+        "metadata_mtime": status.get("metadata_mtime", 0),
+        "graph_stale": status.get("graph_stale", False),
+    }
+    (kb_dir / "kb_manifest.json").write_text(json.dumps(manifest, indent=2))
+
+
 def scan_directory(watch_dir: Path) -> dict:
     """Return {abs_path_str: content_hash} for all processable files."""
     result = {}
-    for root, _, files in os.walk(watch_dir):
+    for root, dirs, files in os.walk(watch_dir):
+        # In-place modify dirs to skip excluded directories
+        dirs[:] = [d for d in dirs if d not in _EXCLUDE_DIRS]
+
         for fname in files:
             if any(fname.endswith(e) for e in _WATCHED_EXTS) and not fname.startswith('.'):
                 p = os.path.join(root, fname)
@@ -76,17 +112,117 @@ def diff_state(watch_dir: Path, old_state: dict) -> tuple[list, list, dict]:
     return changed, deleted, current
 
 
+def _generate_yaml_companions(watch_dir: Path, changed_files: list) -> list:
+    """Generate or merge YAML companions for .go and .py files using go.meta.gen.py / py.meta.gen.py.
+
+    For new source files: generates YAML skeleton.
+    For existing source files with companion YAML: merges updates (preserves human-edited semantic fields).
+
+    Returns list of newly generated/merged .yaml file paths (to be included in processing).
+    """
+    import subprocess
+    generated = []
+
+    # Locate generator scripts (siblings of kb_watch.py)
+    generators_dir = Path(__file__).parent.parent / "tools"
+
+    for file_path in changed_files:
+        ext = Path(file_path).suffix
+        if ext not in _GENERATORS:
+            continue
+
+        yaml_path = Path(file_path).with_suffix('.yaml')
+        generator_name = _GENERATORS[ext]
+        generator_script = generators_dir / generator_name
+
+        if not generator_script.exists():
+            continue  # Generator not available, skip
+
+        try:
+            # Determine if we should merge (YAML exists) or generate fresh
+            if yaml_path.exists():
+                # YAML exists: use --merge to update auto-detected fields while preserving semantics
+                print(f"  [gen] {generator_name} --merge {Path(file_path).name}", flush=True)
+                subprocess.run(
+                    [sys.executable, str(generator_script), "--merge", file_path],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.STDOUT,
+                    timeout=10,
+                    check=False
+                )
+            else:
+                # YAML missing: generate skeleton
+                print(f"  [gen] {generator_name} {Path(file_path).name}", flush=True)
+                subprocess.run(
+                    [sys.executable, str(generator_script), file_path],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.STDOUT,
+                    timeout=10,
+                    check=False
+                )
+
+            if yaml_path.exists():
+                generated.append(str(yaml_path))
+                mode = "merged" if Path(file_path).with_suffix('.yaml').exists() else "generated"
+                print(f"    → {mode} {yaml_path.name}", flush=True)
+        except Exception as e:
+            print(f"    [warn] generator error: {e}", flush=True)
+
+    return generated
+
+
+def _resolve_companion_changes(changed: list, deleted: list) -> tuple[list, list]:
+    """Resolve Markdown companion YAML changes to MD file changes.
+
+    If foo.yaml changes and foo.md exists, process foo.md instead (avoid duplicate chunks).
+    If foo.yaml is deleted and foo.md exists, mark foo.md as changed (to clear stale metadata).
+    """
+    resolved_changed = []
+    resolved_deleted = []
+
+    for fp in changed:
+        if fp.endswith(('.yaml', '.yml')):
+            base = os.path.splitext(fp)[0]
+            md_path = base + '.md'
+            if os.path.exists(md_path):
+                # YAML has Markdown companion: process the .md instead
+                if md_path not in resolved_changed:
+                    resolved_changed.append(md_path)
+            else:
+                # YAML is standalone: process as-is
+                resolved_changed.append(fp)
+        else:
+            resolved_changed.append(fp)
+
+    for fp in deleted:
+        if fp.endswith(('.yaml', '.yml')):
+            base = os.path.splitext(fp)[0]
+            md_path = base + '.md'
+            if os.path.exists(md_path):
+                # YAML deleted but .md still exists: clear .md metadata
+                if md_path not in resolved_changed:
+                    resolved_changed.append(md_path)
+            else:
+                # Both deleted
+                resolved_deleted.append(fp)
+        else:
+            resolved_deleted.append(fp)
+
+    return resolved_changed, resolved_deleted
+
+
 # ── single-file processor dispatch ─────────────────────────────────────────
 
 def _classify_yaml(file_path: str) -> str:
     """Determine which processor handles this YAML: 'go' | 'py' | 'md' | 'generic'."""
     base = os.path.splitext(file_path)[0]
+    # Check for companion Markdown file first (foo.yaml → foo.md)
+    if os.path.exists(base + '.md'):
+        return 'md'
     if os.path.exists(base + '.go'):
         return 'go'
     if os.path.exists(base + '.py'):
         return 'py'
-    if os.path.exists(base + '.md'):
-        return 'md'
     if make_source._is_go_meta_yaml(file_path):
         return 'go'
     if make_source._is_py_meta_yaml(file_path):
@@ -125,7 +261,17 @@ def _load_pkl(kb_dir: Path, name: str, default):
 
 
 def _dump_pkl(kb_dir: Path, name: str, obj) -> None:
-    _pkl_path(kb_dir, name).write_bytes(pickle.dumps(obj))
+    """Atomically write PKL file using temp + rename."""
+    import tempfile
+    target = _pkl_path(kb_dir, name)
+    temp_fd, temp_path = tempfile.mkstemp(dir=target.parent, prefix='.tmp_', suffix='.pkl')
+    try:
+        with os.fdopen(temp_fd, 'wb') as f:
+            f.write(pickle.dumps(obj))
+        os.replace(temp_path, str(target))
+    except Exception:
+        os.unlink(temp_path)
+        raise
 
 
 def _load_chunks(kb_dir: Path) -> dict:
@@ -177,10 +323,14 @@ def incremental_update(watch_dir: Path, changed: list, deleted: list,
         except Exception as exc:
             print(f"  [warn] {os.path.basename(fp)}: {exc}")
 
-    # assign IDs continuing from current max
-    next_id = _next_chunk_id(chunks_by_id)
-    for i, chunk in enumerate(new_chunks):
-        chunk['id'] = f'c{next_id + i}'
+    # assign persistent IDs (file_path + type + section based hash)
+    for chunk in new_chunks:
+        chunk['id'] = _generate_chunk_id(
+            chunk['file_path'],
+            chunk['type'],
+            chunk.get('section', ''),
+            chunk.get('text', '')
+        )
         chunk.setdefault('file_paths', [chunk.get('file_path', '')])
 
     # ── embed only new chunks ─────────────────────────────────────────────
@@ -194,12 +344,22 @@ def incremental_update(watch_dir: Path, changed: list, deleted: list,
     # ── rebuild FAISS from ALL current embeddings (no re-encoding) ────────
     try:
         import faiss as _faiss
+        import tempfile
         if embeddings_by_id:
             id_order = list(embeddings_by_id.keys())
             mat = np.stack([embeddings_by_id[cid] for cid in id_order]).astype('float32')
             faiss_idx = _faiss.IndexFlatIP(mat.shape[1])
             faiss_idx.add(mat)
-            _faiss.write_index(faiss_idx, str(_pkl_path(kb_dir, 'faiss.index')))
+            # Atomic write: temp file + rename
+            target = _pkl_path(kb_dir, 'faiss.index')
+            temp_fd, temp_path = tempfile.mkstemp(dir=target.parent, prefix='.tmp_', suffix='.index')
+            try:
+                os.close(temp_fd)  # Close fd; FAISS will open it
+                _faiss.write_index(faiss_idx, temp_path)
+                os.replace(temp_path, str(target))
+            except Exception:
+                os.unlink(temp_path)
+                raise
     except ImportError:
         pass
 
@@ -214,12 +374,27 @@ def incremental_update(watch_dir: Path, changed: list, deleted: list,
     else:
         inv_index = {}
 
+    # ── rebuild metadata index from ALL current chunks ───────────────────
+    if all_chunks:
+        metadata_index = make_source.build_metadata_index(all_chunks)
+    else:
+        metadata_index = {}
+
     # ── persist ────────────────────────────────────────────────────────────
     _dump_pkl(kb_dir, 'chunks.pkl', chunks_by_id)
+    _dump_pkl(kb_dir, 'metadata_index.pkl', metadata_index)
     _dump_pkl(kb_dir, 'embeddings_by_id.pkl', embeddings_by_id)
     _dump_pkl(kb_dir, 'inverted_index.pkl', inv_index)
 
-    return {'removed': len(stale_ids), 'added': len(new_chunks), 'total': len(chunks_by_id)}
+    return {
+        'removed': len(stale_ids),
+        'added': len(new_chunks),
+        'total': len(chunks_by_id),
+        'chunks_mtime': time.time(),
+        'search_mtime': time.time(),
+        'metadata_mtime': time.time(),
+        'graph_stale': True,  # graph not refreshed by watcher
+    }
 
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -231,19 +406,109 @@ def _load_model(kb_dir: Path):
     return SentenceTransformer(model_name)
 
 
+class KBWatchHandler(FileSystemEventHandler):
+    """inotify event handler for KB updates."""
+
+    def __init__(self, watch_dir: Path, kb_dir: Path, model, file_state: dict):
+        self.watch_dir = watch_dir
+        self.kb_dir = kb_dir
+        self.model = model
+        self.file_state = file_state
+        self.pending_files = set()
+
+    def on_modified(self, event):
+        if not event.is_directory and self._should_process(event.src_path):
+            self.pending_files.add(event.src_path)
+            self._process_changes()
+
+    def on_created(self, event):
+        if not event.is_directory and self._should_process(event.src_path):
+            self.pending_files.add(event.src_path)
+            self._process_changes()
+
+    def on_deleted(self, event):
+        if not event.is_directory and self._should_process(event.src_path):
+            self.pending_files.add(event.src_path)
+            self._process_changes()
+
+    def _should_process(self, file_path: str) -> bool:
+        """Check if file should be processed."""
+        # Check extension and not a hidden file
+        if not (any(file_path.endswith(e) for e in _WATCHED_EXTS) and not os.path.basename(file_path).startswith('.')):
+            return False
+        # Check if it's in an excluded directory
+        for excluded in _EXCLUDE_DIRS:
+            if f'/{excluded}/' in file_path or f'\\{excluded}\\' in file_path:
+                return False
+        return True
+
+    def _process_changes(self):
+        """Detect and process file changes."""
+        changed, deleted, current = diff_state(self.watch_dir, self.file_state)
+
+        # Generator pass: create missing YAML companions for .go and .py files
+        generated = _generate_yaml_companions(self.watch_dir, changed)
+        if generated:
+            changed.extend(generated)
+            # Update file_state to reflect newly generated files
+            for gen_file in generated:
+                current[gen_file] = _file_hash(gen_file)
+
+        # Resolve Markdown companion YAML changes: if foo.yaml changes, process foo.md instead
+        changed, deleted = _resolve_companion_changes(changed, deleted)
+
+        if changed or deleted:
+            ts = time.strftime('%H:%M:%S')
+            print(f"\n[{ts}] {len(changed)} changed, {len(deleted)} deleted")
+            for fp in changed:
+                print(f"  ~ {os.path.relpath(fp, self.watch_dir)}")
+            for fp in deleted:
+                print(f"  - {os.path.relpath(fp, self.watch_dir)}")
+            try:
+                s = incremental_update(self.watch_dir, changed, deleted, self.kb_dir, self.model)
+                self.file_state = current  # Replace state entirely (remove deleted files)
+                save_file_state(self.kb_dir, self.file_state)
+                save_manifest(self.kb_dir, s)
+                print(f"  → removed={s['removed']} added={s['added']} total={s['total']} (graph_stale={s['graph_stale']})")
+            except Exception as e:
+                print(f"  [error] {e}")
+        self.pending_files.clear()
+
+
 def main():
     ap = argparse.ArgumentParser(
-        description='Incremental KB watcher — watches any directory, updates KB PKLs on file change',
+        description='Incremental KB watcher — watches any directory, updates KB PKLs on file change (inotify-based)',
     )
-    ap.add_argument('watch_dir', help='Directory to watch')
-    ap.add_argument('--kb-dir', default='kb_data', help='KB output directory (default: kb_data)')
-    ap.add_argument('--interval', type=float, default=2.0, help='Poll interval in seconds (default: 2)')
+    ap.add_argument(
+        '--source',
+        default=os.environ.get('SOURCE_DIR', './source'),
+        help='Source directory to watch (default: env SOURCE_DIR or ./source)'
+    )
+    ap.add_argument(
+        '--kb-dir',
+        default=os.environ.get('KB_DATA_DIR', './kb_data'),
+        help='KB output directory (default: env KB_DATA_DIR or ./kb_data)'
+    )
     ap.add_argument('--once', action='store_true', help='Single scan then exit')
     args = ap.parse_args()
 
-    watch_dir = Path(args.watch_dir).resolve()
+    watch_dir = Path(args.source).resolve()
     kb_dir = Path(args.kb_dir).resolve()
-    (kb_dir / 'pkl').mkdir(parents=True, exist_ok=True)
+    pkl_dir = kb_dir / 'pkl'
+    pkl_dir.mkdir(parents=True, exist_ok=True)
+
+    # Wait for chunks.pkl if KB is being bootstrapped
+    chunks_pkl = pkl_dir / 'chunks.pkl'
+    if not chunks_pkl.exists():
+        print(f"[watch] waiting for KB bootstrap (chunks.pkl not yet created)...", flush=True)
+        for i in range(600):  # wait up to 10 minutes
+            if chunks_pkl.exists():
+                print(f"[watch] KB bootstrap complete, starting watch...", flush=True)
+                break
+            time.sleep(1)
+        else:
+            print(f"[watch] timeout waiting for KB bootstrap", file=sys.stderr)
+            return
 
     model = _load_model(kb_dir)
     file_state = load_file_state(kb_dir)
@@ -259,23 +524,20 @@ def main():
         return
 
     print(f"Watching {watch_dir}")
-    print(f"KB:       {kb_dir}  (interval: {args.interval}s — Ctrl-C to stop)")
+    print(f"KB:       {kb_dir}")
+    print("Press Ctrl-C to stop\n")
+
+    event_handler = KBWatchHandler(watch_dir, kb_dir, model, file_state)
+    observer = Observer()
+    observer.schedule(event_handler, str(watch_dir), recursive=True)
+    observer.start()
+
     try:
         while True:
-            changed, deleted, current = diff_state(watch_dir, file_state)
-            if changed or deleted:
-                ts = time.strftime('%H:%M:%S')
-                print(f"\n[{ts}] {len(changed)} changed, {len(deleted)} deleted")
-                for fp in changed:
-                    print(f"  ~ {os.path.relpath(fp, watch_dir)}")
-                for fp in deleted:
-                    print(f"  - {os.path.relpath(fp, watch_dir)}")
-                s = incremental_update(watch_dir, changed, deleted, kb_dir, model)
-                file_state = current
-                save_file_state(kb_dir, file_state)
-                print(f"  → removed={s['removed']} added={s['added']} total={s['total']}")
-            time.sleep(args.interval)
+            time.sleep(1)
     except KeyboardInterrupt:
+        observer.stop()
+        observer.join()
         print("\nStopped.")
 
 

--- a/mcp-server/kb_watch.yaml
+++ b/mcp-server/kb_watch.yaml
@@ -1,0 +1,302 @@
+---
+module: kb_watch
+description: 'kb_watch.py — Incremental KB updater for development use. Watches any
+  directory for file changes and keeps the knowledge base PKLs up-to-date without
+  a full rebuild.  Only newly changed files are re-processed; existing embeddings
+  are reused from the sidecar `embeddings_by_id.pkl`. Works with any repo or directory
+  — not MCP-specific. Usage: python mcp-server/kb_watch.py <watch_dir> [--kb-dir kb_data]
+  [--interval 2] python mcp-server/kb_watch.py <watch_dir> --once    # single scan
+  + exit'
+tags:
+- core
+- gateway
+- interface
+- loader
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: _STATE_FILE
+  kind: const
+  description: ''
+  references: []
+- name: _WATCHED_EXTS
+  kind: const
+  description: ''
+  references: []
+- name: _GENERATORS
+  kind: const
+  description: ''
+  references: []
+- name: _EXCLUDE_DIRS
+  kind: const
+  description: ''
+  references: []
+- name: _file_hash
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - f.read
+- name: load_file_state
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - p.exists
+  - p.read_text
+- name: save_file_state
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls: []
+- name: save_manifest
+  kind: function
+  decorators: []
+  description: Write kb_manifest.json with index version info.
+  references: []
+  calls:
+  - status.get
+- name: scan_directory
+  kind: function
+  decorators: []
+  description: 'Return {abs_path_str: content_hash} for all processable files.'
+  references: []
+  calls:
+  - _file_hash
+  - fname.endswith
+  - fname.startswith
+- name: diff_state
+  kind: function
+  decorators: []
+  description: Return (changed_or_new, deleted, current_scan).
+  references: []
+  calls:
+  - current.items
+  - old_state.get
+- name: _generate_yaml_companions
+  kind: function
+  decorators: []
+  description: 'Generate or merge YAML companions for .go and .py files using go.meta.gen.py
+    / py.meta.gen.py. For new source files: generates YAML skeleton. For existing
+    source files with companion YAML: merges updates (preserves human-edited semantic
+    fields). Returns list of newly generated/merged .yaml file paths (to be included
+    in processing).'
+  references: []
+  calls:
+  - generated.append
+  - generator_script.exists
+  - yaml_path.exists
+- name: _resolve_companion_changes
+  kind: function
+  decorators: []
+  description: Resolve Markdown companion YAML changes to MD file changes. If foo.yaml
+    changes and foo.md exists, process foo.md instead (avoid duplicate chunks). If
+    foo.yaml is deleted and foo.md exists, mark foo.md as changed (to clear stale
+    metadata).
+  references: []
+  calls:
+  - fp.endswith
+  - resolved_changed.append
+  - resolved_deleted.append
+- name: _classify_yaml
+  kind: function
+  decorators: []
+  description: 'Determine which processor handles this YAML: ''go'' | ''py'' | ''md''
+    | ''generic''.'
+  references:
+  - make_source._is_py_meta_yaml
+  - make_source._is_go_meta_yaml
+  calls:
+  - make_source._is_go_meta_yaml
+  - make_source._is_py_meta_yaml
+- name: process_file
+  kind: function
+  decorators: []
+  description: Route a single file to the correct make_source processor.
+  references:
+  - make_source.process_yaml_file
+  - make_source.process_py_yaml
+  - make_source.process_go_yaml
+  - make_source.process_md_file
+  calls:
+  - _classify_yaml
+  - file_path.endswith
+  - make_source.process_go_yaml
+  - make_source.process_md_file
+  - make_source.process_py_yaml
+  - make_source.process_yaml_file
+- name: _pkl_path
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls: []
+- name: _load_pkl
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - _pkl_path
+  - p.exists
+  - p.open
+- name: _dump_pkl
+  kind: function
+  decorators: []
+  description: Atomically write PKL file using temp + rename.
+  references: []
+  calls:
+  - _pkl_path
+  - f.write
+  - tempfile.mkstemp
+- name: _load_chunks
+  kind: function
+  decorators: []
+  description: Load chunks.pkl and normalize to dict[chunk_id, chunk_dict].
+  references: []
+  calls:
+  - _load_pkl
+- name: _chunks_for_files
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - c.get
+  - chunks_by_id.items
+- name: _next_chunk_id
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - cid.startswith
+- name: incremental_update
+  kind: function
+  decorators: []
+  description: 'Process changed/deleted files and update KB PKLs in-place. Returns
+    a summary dict: {removed, added, total}.'
+  references:
+  - make_source.build_metadata_index
+  - make_source.create_bm25_inverted_index
+  - make_source.build_bm25_index
+  - numpy.stack
+  - make_source._generate_chunk_id
+  calls:
+  - _chunks_for_files
+  - _dump_pkl
+  - _faiss.IndexFlatIP
+  - _faiss.write_index
+  - _load_chunks
+  - _load_pkl
+  - _pkl_path
+  - c.get
+  - chunk.get
+  - chunk.setdefault
+  - chunks_by_id.pop
+  - chunks_by_id.values
+  - embeddings_by_id.keys
+  - embeddings_by_id.pop
+  - faiss_idx.add
+  - make_source._generate_chunk_id
+  - make_source.build_bm25_index
+  - make_source.build_metadata_index
+  - make_source.create_bm25_inverted_index
+  - model.encode
+  - new_chunks.extend
+  - numpy.stack
+  - tempfile.mkstemp
+  - vec.astype
+- name: _load_model
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - make_source.EMBEDDING_MODEL
+  calls:
+  - SentenceTransformer
+  - _load_pkl
+- name: KBWatchHandler
+  kind: class
+  decorators: []
+  description: inotify event handler for KB updates.
+  implements:
+  - FileSystemEventHandler
+  references:
+  - watchdog.events.FileSystemEventHandler
+- name: __init__
+  kind: method
+  receiver: KBWatchHandler
+  decorators: []
+  description: ''
+  references: []
+  calls: []
+- name: on_modified
+  kind: method
+  receiver: KBWatchHandler
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - self._process_changes
+  - self._should_process
+- name: on_created
+  kind: method
+  receiver: KBWatchHandler
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - self._process_changes
+  - self._should_process
+- name: on_deleted
+  kind: method
+  receiver: KBWatchHandler
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - self._process_changes
+  - self._should_process
+- name: _should_process
+  kind: method
+  receiver: KBWatchHandler
+  decorators: []
+  description: Check if file should be processed.
+  references: []
+  calls:
+  - file_path.endswith
+- name: _process_changes
+  kind: method
+  receiver: KBWatchHandler
+  decorators: []
+  description: Detect and process file changes.
+  references: []
+  calls:
+  - _file_hash
+  - _generate_yaml_companions
+  - _resolve_companion_changes
+  - changed.extend
+- name: main
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - watchdog.observers.Observer
+  calls:
+  - KBWatchHandler
+  - _load_model
+  - ap.add_argument
+  - ap.parse_args
+  - chunks_pkl.exists
+  - observer.join
+  - observer.schedule
+  - observer.start
+  - observer.stop
+  - pkl_dir.mkdir
+  - watchdog.observers.Observer

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -45,6 +45,7 @@ FAISS_INDEX = Path(os.environ.get("FAISS_INDEX", str(DATA_DIR / "faiss.index")))
 BM25_PKL = Path(os.environ.get("BM25_PKL", str(DATA_DIR / "bm25.pkl")))
 CHUNK_IDS_PKL = Path(os.environ.get("CHUNK_IDS_PKL", str(DATA_DIR / "chunk_ids.pkl")))
 MODEL_NAME_PKL = Path(os.environ.get("MODEL_NAME_PKL", str(DATA_DIR / "model_name.pkl")))
+METADATA_INDEX_PKL = Path(os.environ.get("METADATA_INDEX_PKL", str(DATA_DIR / "metadata_index.pkl")))
 
 # Limits and Configuration
 DEFAULT_TOPK = int(os.environ.get("TOPK", "10"))
@@ -234,6 +235,7 @@ def load_kb() -> dict[str, Any]:
         "faiss_chunk_ids": faiss_chunk_ids,
         "bm25": bm25,
         "embedding_model": embedding_model,
+        "meta_idx": load_one(METADATA_INDEX_PKL) if METADATA_INDEX_PKL.exists() else {},
     }
 
 
@@ -571,47 +573,66 @@ def search_code(code_snippet: str, top_k: int = DEFAULT_TOPK) -> list[dict]:
 
 @mcp.tool()
 def search_nodes(query: str, top_k: int = DEFAULT_TOPK) -> list[dict]:
-    """Search for nodes by name, label, type, or tags.
+    """Search for nodes by name, label, type, tags, or category.
 
-    Useful when you know the concept name but not the exact text content.
+    Uses the metadata index for O(1) tag/category lookup, then augments
+    with linear label/type scan for full coverage.
     """
     kb = load_kb()
     q = query.lower().strip()
-    results = []
     limit = _clamp_topk(top_k)
+    meta_idx = kb.get("meta_idx", {})
 
+    # Collect candidate chunk_ids from metadata index (O(1))
+    boosted_chunks: dict[str, int] = {}
+    for tag, cids in meta_idx.get("tag_index", {}).items():
+        if q in tag.lower():
+            for cid in cids:
+                boosted_chunks[cid] = boosted_chunks.get(cid, 0) + 2
+    for cat, cids in meta_idx.get("category_index", {}).items():
+        if q in cat.lower():
+            for cid in cids:
+                boosted_chunks[cid] = boosted_chunks.get(cid, 0) + 2
+
+    # Map chunk_ids back to node_ids for boosted set
+    chunk_to_nodes = kb.get("chunk_to_nodes", {})
+    boosted_nodes: dict[str, int] = {}
+    for cid, bonus in boosted_chunks.items():
+        for nid in chunk_to_nodes.get(cid, []):
+            boosted_nodes[nid] = boosted_nodes.get(nid, 0) + bonus
+
+    # Linear scan for label/type/id matches
+    scores: dict[str, int] = dict(boosted_nodes)
     for nid, node in kb["nodes"].items():
         if not isinstance(node, dict):
             continue
-
-        score = 0
-        # Check ID
+        s = scores.get(nid, 0)
         if q in str(nid).lower():
-            score += 4
-        # Check Label/Name
+            s += 4
         label = str(node.get("label") or node.get("name") or "")
         if q in label.lower():
-            score += 3
-        # Check Type/Category
-        cat = str(node.get("type") or node.get("category") or "")
+            s += 3
+        cat = str(node.get("type") or "")
         if q in cat.lower():
-            score += 2
-        # Check Tags
-        tags = node.get("tags") or []
-        if isinstance(tags, list):
-            for t in tags:
-                if q in str(t).lower():
-                    score += 1
-                    break
+            s += 1
+        if s > 0:
+            scores[nid] = s
 
-        if score > 0:
-            results.append({
-                "node_id": nid,
-                "score": score,
-                "label": label,
-                "type": cat,
-                "chunk_id": node.get("chunk_id")
-            })
+    results = []
+    for nid, score in scores.items():
+        node = kb["nodes"].get(nid)
+        if not isinstance(node, dict):
+            continue
+        label = str(node.get("label") or node.get("name") or "")
+        results.append({
+            "node_id": nid,
+            "score": score,
+            "label": label,
+            "type": str(node.get("type") or ""),
+            "tags": node.get("tags", []),
+            "category": node.get("category", []),
+            "chunk_id": node.get("chunk_id"),
+        })
 
     # Sort by score
     results.sort(key=lambda x: x["score"], reverse=True)
@@ -907,49 +928,51 @@ def find_nodes(
     category: Optional[str] = None,
     tag: Optional[str] = None,
     used_in: Optional[str] = None,
-    limit: int = 50,
+    top_k: int = 50,
 ) -> list[dict]:
-    """Filter nodes by metadata (if present).
+    """Filter nodes by metadata using the prebuilt metadata index (O(1) lookup).
 
-    Expects node payload to possibly contain fields like:
-    - category (str or list)
-    - tags (list[str])
-    - used_in (list[str] or str)
+    Args:
+        category: Filter by category (exact match).
+        tag:      Filter by tag (exact match).
+        used_in:  Filter by used_in context (exact match).
+        top_k:    Max results.
     """
     kb = load_kb()
+    meta_idx = kb.get("meta_idx", {})
+    chunk_to_nodes = kb.get("chunk_to_nodes", {})
+    limit = _clamp_topk(top_k)
+
+    # Start with the full set of chunk_ids, then intersect per filter
+    candidate_sets: list[set[str]] = []
+
+    if tag:
+        cids = set(meta_idx.get("tag_index", {}).get(tag.lower(), []))
+        candidate_sets.append(cids)
+    if category:
+        cids = set(meta_idx.get("category_index", {}).get(category.lower(), []))
+        candidate_sets.append(cids)
+    if used_in:
+        cids = set(meta_idx.get("used_in_index", {}).get(used_in.lower(), []))
+        candidate_sets.append(cids)
+
+    if not candidate_sets:
+        return []
+
+    # Intersect all filter sets
+    matched_chunks = candidate_sets[0]
+    for s in candidate_sets[1:]:
+        matched_chunks = matched_chunks & s
+
+    # Resolve chunk_ids → nodes
     out: list[dict] = []
-    cat = category.lower() if category else None
-    tg = tag.lower() if tag else None
-    ui = used_in.lower() if used_in else None
-
-    for n in kb["nodes"].values():
-        if not isinstance(n, dict):
-            continue
-
-        if cat:
-            v = n.get("category")
-            ok = (isinstance(v, str) and v.lower() == cat) or (isinstance(v, list) and any(str(x).lower() == cat for x in v))
-            if not ok:
-                continue
-
-        if tg:
-            v = n.get("tags") or []
-            if isinstance(v, str):
-                v = [v]
-            if not (isinstance(v, list) and any(str(x).lower() == tg for x in v)):
-                continue
-
-        if ui:
-            v = n.get("used_in") or []
-            if isinstance(v, str):
-                v = [v]
-            if not (isinstance(v, list) and any(str(x).lower() == ui for x in v)):
-                continue
-
-        out.append(n)
-        if len(out) >= _clamp_topk(limit):
-            break
-
+    for cid in matched_chunks:
+        for nid in chunk_to_nodes.get(cid, []):
+            node = kb["nodes"].get(nid)
+            if isinstance(node, dict):
+                out.append(node)
+            if len(out) >= limit:
+                return out
     return out
 
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1,0 +1,921 @@
+#!/usr/bin/env python3
+"""
+Graph MCP server for CIC knowledge base stored in PKL files (legacy format supported).
+
+Read-only MCP server that exposes:
+- token search via inverted_index.pkl
+- chunk/node lookup
+- graph traversal (neighbors)
+- simple filtering (by tag/category/used_in) if metadata exists in node/chunk payloads
+- focus_pack: context gathering with rule prioritization
+- explain_node: deep dive into specific nodes
+- search_nodes: lookup nodes by name/label/tags
+- kb_status: check KB file status
+- reload_kb: force-reload the knowledge base
+
+Works with stdio (default) and SSE (HTTP) if you wrap it similarly to your docs_mcp.py.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import re
+import argparse
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("cic-graph")
+
+# Adjust paths to point to the correct location relative to this script
+BASE_DIR = Path(__file__).parent.parent
+DATA_DIR = Path(os.environ.get("KB_DATA_DIR", str(BASE_DIR / "kb_data" / "pkl")))
+
+CHUNKS_PKL = Path(os.environ.get("CHUNKS_PKL", str(DATA_DIR / "chunks.pkl")))
+NODES_PKL = Path(os.environ.get("NODES_PKL", str(DATA_DIR / "graph_nodes.pkl")))
+EDGES_PKL = Path(os.environ.get("EDGES_PKL", str(DATA_DIR / "graph_edges.pkl")))
+INVERTED_PKL = Path(os.environ.get("INVERTED_PKL", str(DATA_DIR / "inverted_index.pkl")))
+
+# Limits and Configuration
+DEFAULT_TOPK = int(os.environ.get("TOPK", "10"))
+MAX_TOPK = int(os.environ.get("MAX_TOPK", "50"))
+MAX_NEIGHBORS = int(os.environ.get("MAX_NEIGHBORS", "200"))
+MAX_RESOLVE_MATCHES = int(os.environ.get("MAX_RESOLVE_MATCHES", "200"))
+MAX_SEARCH_CODE_HITS = int(os.environ.get("MAX_SEARCH_CODE_HITS", "10"))
+ENABLE_SEARCH_CODE = os.environ.get("ENABLE_SEARCH_CODE", "true").lower() == "true"
+
+# Rule prioritization constants
+RULE_HINTS = [
+    "contract",
+    "definition of done",
+    "dod",
+    "limits",
+    "symbols",
+    "llm lock",
+    "llm_lock",
+    "golden",
+    "verify",
+    "commit / pr",
+]
+
+RULE_FILE_HINTS = [
+    "contract.md",
+    "limits.md",
+    "symbols.md",
+    "llm_lock.md",
+    "contributing.md",
+    "testing.md",
+]
+
+
+def _clamp_topk(k: int) -> int:
+    return max(1, min(int(k), MAX_TOPK))
+
+
+def _normalize_line_range(val: Any) -> Optional[list[int]]:
+    """Normalize line range to [start, end] list of ints or None."""
+    if not val:
+        return None
+    if isinstance(val, list) and len(val) == 2:
+        try:
+            return [int(val[0]), int(val[1])]
+        except (ValueError, TypeError):
+            pass
+    return None
+
+
+@lru_cache(maxsize=1)
+def load_kb() -> dict[str, Any]:
+    """Load all PKL artifacts into memory once."""
+    def load_one(p: Path) -> Any:
+        if not p.exists():
+            raise FileNotFoundError(f"Missing: {p}")
+        with p.open("rb") as f:
+            return pickle.load(f)
+
+    chunks = load_one(CHUNKS_PKL)
+    nodes = load_one(NODES_PKL)
+    edges = load_one(EDGES_PKL)
+    inverted = load_one(INVERTED_PKL)
+
+    # Normalize chunks container:
+    # Supported:
+    # - legacy: chunks.pkl == {"chunks": {cid: {...}, ...}}
+    # - alt:    {"chunks": [...]} or {cid: {...}} or [...]
+    chunks_by_id: dict[str, dict] = {}
+    if isinstance(chunks, dict):
+        # legacy wrapper: {"chunks": {id: obj}}
+        if "chunks" in chunks and isinstance(chunks["chunks"], dict):
+            for k, v in chunks["chunks"].items():
+                if isinstance(v, dict):
+                    chunks_by_id[str(k)] = v
+        # list wrapper: {"chunks": [...]}
+        elif "chunks" in chunks and isinstance(chunks["chunks"], list):
+            for c in chunks["chunks"]:
+                if isinstance(c, dict) and "id" in c:
+                    chunks_by_id[str(c["id"])] = c
+        else:
+            for k, v in chunks.items():
+                if isinstance(v, dict):
+                    chunks_by_id[str(k)] = v
+    elif isinstance(chunks, list):
+        for c in chunks:
+            if isinstance(c, dict) and "id" in c:
+                chunks_by_id[str(c["id"])] = c
+
+    # Nodes container
+    # Supported:
+    # - legacy: graph_nodes.pkl == {"graph_nodes": {nid: {...}, ...}}
+    # - alt:    {"nodes": [...]} or {nid: {...}} or [...]
+    nodes_by_id: dict[str, dict] = {}
+    if isinstance(nodes, dict):
+        # legacy wrapper: {"graph_nodes": {id: obj}}
+        if "graph_nodes" in nodes and isinstance(nodes["graph_nodes"], dict):
+            for k, v in nodes["graph_nodes"].items():
+                if isinstance(v, dict):
+                    nodes_by_id[str(k)] = v
+        # list wrapper: {"nodes": [...]}
+        elif "nodes" in nodes and isinstance(nodes["nodes"], list):
+            for n in nodes["nodes"]:
+                if isinstance(n, dict) and "id" in n:
+                    nodes_by_id[str(n["id"])] = n
+        else:
+            for k, v in nodes.items():
+                if isinstance(v, dict):
+                    nodes_by_id[str(k)] = v
+    elif isinstance(nodes, list):
+        for n in nodes:
+            if isinstance(n, dict) and "id" in n:
+                nodes_by_id[str(n["id"])] = n
+
+    # Edges container
+    edges_list: list[dict] = []
+    # Supported:
+    # - legacy: graph_edges.pkl == {"graph_edges": {eid: {...}, ...}}
+    # - alt:    {"edges": [...]} or {eid: {...}} or [...]
+    if isinstance(edges, dict) and "graph_edges" in edges and isinstance(edges["graph_edges"], dict):
+        edges_list = [e for e in edges["graph_edges"].values() if isinstance(e, dict)]
+    elif isinstance(edges, dict) and "edges" in edges and isinstance(edges["edges"], list):
+        edges_list = edges["edges"]
+    elif isinstance(edges, dict):
+        # dict[eid -> edge_obj]
+        edges_list = [e for e in edges.values() if isinstance(e, dict)]
+    elif isinstance(edges, list):
+        edges_list = edges
+
+    # Build adjacency
+    adj: dict[str, list[dict]] = {}
+    for e in edges_list:
+        if not isinstance(e, dict):
+            continue
+        src = str(e.get("source") or e.get("from") or e.get("src") or "")
+        if not src:
+            continue
+        adj.setdefault(src, []).append(e)
+
+    # Build chunk_id -> list[node_id] index for fast lookup
+    chunk_to_nodes: dict[str, list[str]] = {}
+    for nid, node in nodes_by_id.items():
+        cid = node.get("chunk_id")
+        if cid:
+            chunk_to_nodes.setdefault(str(cid), []).append(nid)
+
+    # Inverted index is usually dict[token -> list[{chunk_id, score}]]
+    inverted_index: dict[str, list[dict]] = {}
+    if isinstance(inverted, dict):
+        # legacy: inverted_index.pkl == {"inverted_index": {token: [...]}}
+        inverted_index = inverted.get("inverted_index", inverted)
+
+    return {
+        "chunks": chunks_by_id,
+        "nodes": nodes_by_id,
+        "edges": edges_list,
+        "adj": adj,
+        "chunk_to_nodes": chunk_to_nodes,
+        "inverted": inverted_index,
+    }
+
+
+def _tokenize(q: str) -> list[str]:
+    # Align closer to make_source.py: lowercase + alpha-only tokens.
+    # This also keeps Hungarian accented letters (isalpha() == True).
+    # (No stopword removal here to keep server lightweight and deterministic.)
+    return [
+        w for w in re.findall(r"\w+", q.lower(), flags=re.UNICODE)
+        if w.isalpha()
+    ]
+
+
+def _extract_chunk_text(chunk: dict) -> str:
+    content = chunk.get("content")
+    if isinstance(content, str) and content:
+        return content
+    text = chunk.get("text")
+    if isinstance(text, str):
+        return text
+    return ""
+
+
+def _extract_chunk_file_path(chunk: dict) -> str:
+    meta = chunk.get("metadata", {})
+    if not isinstance(meta, dict):
+        meta = {}
+    return str(
+        chunk.get("file_path")
+        or meta.get("file_path")
+        or chunk.get("path")
+        or meta.get("path")
+        or ""
+    )
+
+
+def _extract_chunk_section(chunk: dict) -> str:
+    meta = chunk.get("metadata", {})
+    if not isinstance(meta, dict):
+        meta = {}
+    return str(
+        chunk.get("section")
+        or meta.get("section")
+        or ""
+    )
+
+
+def _rule_bonus_for_chunk(chunk: dict) -> float:
+    """
+    Give a deterministic bonus to rule-like chunks/files.
+    """
+    file_path = _extract_chunk_file_path(chunk).lower()
+    section = _extract_chunk_section(chunk).lower()
+    text = _extract_chunk_text(chunk)[:1200].lower()
+
+    bonus = 0.0
+
+    for hint in RULE_FILE_HINTS:
+        if hint in file_path:
+            bonus += 2.0
+
+    for hint in RULE_HINTS:
+        if hint in section:
+            bonus += 1.5
+        if hint in text:
+            bonus += 0.75
+
+    return bonus
+
+
+def _kb_mtimes() -> dict[str, float | None]:
+    return {
+        "chunks": CHUNKS_PKL.stat().st_mtime if CHUNKS_PKL.exists() else None,
+        "nodes": NODES_PKL.stat().st_mtime if NODES_PKL.exists() else None,
+        "edges": EDGES_PKL.stat().st_mtime if EDGES_PKL.exists() else None,
+        "inverted": INVERTED_PKL.stat().st_mtime if INVERTED_PKL.exists() else None,
+    }
+
+
+@mcp.tool()
+def kb_status() -> dict:
+    """Return detailed status about loaded KB artifacts."""
+    return {
+        "data_dir": str(DATA_DIR),
+        "cache_info": load_kb.cache_info()._asdict(),
+        "files": {
+            "chunks": {
+                "path": str(CHUNKS_PKL),
+                "exists": CHUNKS_PKL.exists(),
+                "mtime": CHUNKS_PKL.stat().st_mtime if CHUNKS_PKL.exists() else None,
+                "size": CHUNKS_PKL.stat().st_size if CHUNKS_PKL.exists() else None,
+            },
+            "nodes": {
+                "path": str(NODES_PKL),
+                "exists": NODES_PKL.exists(),
+                "mtime": NODES_PKL.stat().st_mtime if NODES_PKL.exists() else None,
+                "size": NODES_PKL.stat().st_size if NODES_PKL.exists() else None,
+            },
+            "edges": {
+                "path": str(EDGES_PKL),
+                "exists": EDGES_PKL.exists(),
+                "mtime": EDGES_PKL.stat().st_mtime if EDGES_PKL.exists() else None,
+                "size": EDGES_PKL.stat().st_size if EDGES_PKL.exists() else None,
+            },
+            "inverted": {
+                "path": str(INVERTED_PKL),
+                "exists": INVERTED_PKL.exists(),
+                "mtime": INVERTED_PKL.stat().st_mtime if INVERTED_PKL.exists() else None,
+                "size": INVERTED_PKL.stat().st_size if INVERTED_PKL.exists() else None,
+            },
+        }
+    }
+
+
+@mcp.tool()
+def reload_kb() -> dict:
+    """
+    Force reload of KB artifacts from disk.
+    Useful after regenerating PKL files.
+    """
+    before = _kb_mtimes()
+    load_kb.cache_clear()
+    kb = load_kb()
+    after = _kb_mtimes()
+
+    return {
+        "reloaded": True,
+        "chunks": len(kb["chunks"]),
+        "nodes": len(kb["nodes"]),
+        "edges": len(kb["edges"]),
+        "tokens": len(kb["inverted"]),
+        "mtimes_before": before,
+        "mtimes_after": after,
+    }
+
+
+@mcp.tool()
+def list_edge_types() -> list[str]:
+    """List all unique edge types found in the graph."""
+    kb = load_kb()
+    types = set()
+    for e in kb["edges"]:
+        if isinstance(e, dict):
+            t = e.get("type") or e.get("edge_type")
+            if t:
+                types.add(str(t))
+    return sorted(types)
+
+
+@mcp.tool()
+def list_node_types() -> list[str]:
+    """List all unique node types (categories) found in the graph."""
+    kb = load_kb()
+    types = set()
+    for n in kb["nodes"].values():
+        if isinstance(n, dict):
+            # Try 'type' or 'category'
+            t = n.get("type") or n.get("category")
+            if t:
+                if isinstance(t, list):
+                    for x in t:
+                        types.add(str(x))
+                else:
+                    types.add(str(t))
+    return sorted(types)
+
+
+@mcp.tool()
+def search_token(token: str, top_k: int = DEFAULT_TOPK) -> list[dict]:
+    """Search a single token in the inverted index.
+
+    Returns a list of {chunk_id, score}.
+    """
+    kb = load_kb()
+    t = token.strip().lower()
+    hits = kb["inverted"].get(t, [])
+    hits_sorted = sorted(
+        (h for h in hits if isinstance(h, dict) and "chunk_id" in h),
+        key=lambda x: float(x.get("score", 0.0)),
+        reverse=True,
+    )
+    return hits_sorted[:_clamp_topk(top_k)]
+
+
+@mcp.tool()
+def search_query(query: str, top_k: int = DEFAULT_TOPK, threshold: float = 0.0) -> list[dict]:
+    """Multi-token search using inverted index (simple OR + sum scores).
+
+    Returns ranked chunks: {chunk_id, score, matched_tokens, file_path, line_range}.
+    """
+    kb = load_kb()
+    tokens = _tokenize(query)
+    if not tokens:
+        return []
+
+    scores: dict[str, float] = {}
+    matched: dict[str, set[str]] = {}
+
+    for t in tokens:
+        for h in kb["inverted"].get(t, []):
+            if not isinstance(h, dict):
+                continue
+            cid = h.get("chunk_id")
+            if not cid:
+                continue
+            cid = str(cid)
+            s = float(h.get("score", 0.0))
+            scores[cid] = scores.get(cid, 0.0) + s
+            matched.setdefault(cid, set()).add(t)
+
+    # Filter by threshold and sort
+    ranked = [
+        (cid, sc) for cid, sc in scores.items()
+        if sc >= threshold
+    ]
+    ranked.sort(key=lambda kv: kv[1], reverse=True)
+    ranked = ranked[:_clamp_topk(top_k)]
+
+    results = []
+    for cid, sc in ranked:
+        chunk = kb["chunks"].get(cid, {})
+        # Extract metadata
+        meta = chunk.get("metadata", {})
+        if not isinstance(meta, dict):
+            meta = {}
+
+        # Try to find file path in various places
+        file_path = (
+            chunk.get("file_path") or
+            meta.get("file_path") or
+            chunk.get("path") or
+            meta.get("path")
+        )
+
+        # Try to find line range
+        raw_lines = (
+            chunk.get("line_range") or
+            meta.get("line_range") or
+            chunk.get("lines") or
+            meta.get("lines")
+        )
+        line_range = _normalize_line_range(raw_lines)
+
+        results.append({
+            "chunk_id": cid,
+            "score": sc,
+            "matched_tokens": sorted(matched.get(cid, set())),
+            "file_path": file_path,
+            "line_range": line_range,
+        })
+
+    return results
+
+
+@mcp.tool()
+def search_code(code_snippet: str, top_k: int = DEFAULT_TOPK) -> list[dict]:
+    """Substring search in chunk content (slow, linear scan).
+
+    Useful for finding exact code snippets or literal strings that token search misses.
+    Returns: {chunk_id, content_preview, file_path, line_range}
+    """
+    if not ENABLE_SEARCH_CODE:
+        return []
+
+    kb = load_kb()
+    snippet = code_snippet.strip()
+    if not snippet:
+        return []
+
+    results = []
+    # Use stricter limit for linear scan
+    limit = min(_clamp_topk(top_k), MAX_SEARCH_CODE_HITS)
+
+    for cid, chunk in kb["chunks"].items():
+        if not isinstance(chunk, dict):
+            continue
+        content = chunk.get("content") or chunk.get("text") or ""
+        if not isinstance(content, str):
+            continue
+
+        if snippet in content:
+            # Simple preview: 50 chars around the match
+            idx = content.find(snippet)
+            start = max(0, idx - 50)
+            end = min(len(content), idx + len(snippet) + 50)
+            preview = "..." + content[start:end].replace("\n", " ") + "..."
+
+            # Extract metadata
+            meta = chunk.get("metadata", {})
+            if not isinstance(meta, dict):
+                meta = {}
+
+            file_path = (
+                chunk.get("file_path") or
+                meta.get("file_path") or
+                chunk.get("path") or
+                meta.get("path")
+            )
+
+            raw_lines = (
+                chunk.get("line_range") or
+                meta.get("line_range") or
+                chunk.get("lines") or
+                meta.get("lines")
+            )
+            line_range = _normalize_line_range(raw_lines)
+
+            results.append({
+                "chunk_id": cid,
+                "preview": preview,
+                "file_path": file_path,
+                "line_range": line_range
+            })
+            if len(results) >= limit:
+                break
+
+    return results
+
+
+@mcp.tool()
+def search_nodes(query: str, limit: int = 10) -> list[dict]:
+    """Search for nodes by name, label, type, or tags.
+
+    Useful when you know the concept name but not the exact text content.
+    """
+    kb = load_kb()
+    q = query.lower().strip()
+    results = []
+    limit = _clamp_topk(limit)
+
+    for nid, node in kb["nodes"].items():
+        if not isinstance(node, dict):
+            continue
+
+        score = 0
+        # Check ID
+        if q in str(nid).lower():
+            score += 4
+        # Check Label/Name
+        label = str(node.get("label") or node.get("name") or "")
+        if q in label.lower():
+            score += 3
+        # Check Type/Category
+        cat = str(node.get("type") or node.get("category") or "")
+        if q in cat.lower():
+            score += 2
+        # Check Tags
+        tags = node.get("tags") or []
+        if isinstance(tags, list):
+            for t in tags:
+                if q in str(t).lower():
+                    score += 1
+                    break
+
+        if score > 0:
+            results.append({
+                "node_id": nid,
+                "score": score,
+                "label": label,
+                "type": cat,
+                "chunk_id": node.get("chunk_id")
+            })
+
+    # Sort by score
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return results[:limit]
+
+
+@mcp.tool()
+def resolve_path(file_path: str, mode: str = "prefix", limit: int = 200) -> list[dict]:
+    """Find chunks belonging to a specific file path.
+
+    Args:
+        file_path: The path string to search for.
+        mode: Matching mode.
+            - "prefix": Matches if chunk path starts with file_path (default).
+            - "contains": Matches if file_path is a substring of chunk path.
+            - "exact": Matches if chunk path equals file_path.
+        limit: Max number of chunks to return (default 200).
+
+    Returns: list of {chunk_id, line_range, file_path}
+    """
+    kb = load_kb()
+    target = file_path.strip().lower()
+    results = []
+    mode = mode.lower()
+
+    # Clamp limit
+    max_res = max(1, min(limit, MAX_RESOLVE_MATCHES))
+
+    for cid, chunk in kb["chunks"].items():
+        if not isinstance(chunk, dict):
+            continue
+
+        meta = chunk.get("metadata", {})
+        if not isinstance(meta, dict):
+            meta = {}
+
+        # Check path match
+        path_raw = (
+            chunk.get("file_path") or
+            meta.get("file_path") or
+            chunk.get("path") or
+            meta.get("path") or ""
+        )
+        path_str = str(path_raw).lower()
+
+        match = False
+        if mode == "exact":
+            match = (path_str == target)
+        elif mode == "contains":
+            match = (target in path_str)
+        else: # prefix (default)
+            match = path_str.startswith(target)
+
+        if match:
+            raw_lines = (
+                chunk.get("line_range") or
+                meta.get("line_range") or
+                chunk.get("lines") or
+                meta.get("lines")
+            )
+            line_range = _normalize_line_range(raw_lines)
+
+            results.append({
+                "chunk_id": cid,
+                "file_path": path_raw,
+                "line_range": line_range
+            })
+
+            if len(results) >= max_res:
+                break
+
+    return results
+
+
+@mcp.tool()
+def get_chunk(chunk_id: str, max_chars: int = 8000) -> Optional[dict]:
+    """Return a chunk by id.
+
+    Args:
+        chunk_id: The ID of the chunk.
+        max_chars: Maximum characters of content to return (default 8000).
+    """
+    kb = load_kb()
+    chunk = kb["chunks"].get(str(chunk_id))
+    if not chunk:
+        return None
+
+    # Create a copy to avoid modifying the cached object
+    out = chunk.copy()
+
+    # Truncate content if present
+    content = out.get("content") or out.get("text")
+    if isinstance(content, str) and len(content) > max_chars:
+        out["content"] = content[:max_chars] + "... (truncated)"
+        # Also update 'text' alias if present
+        if "text" in out:
+            out["text"] = out["content"]
+
+    return out
+
+
+@mcp.tool()
+def get_node(node_id: str) -> Optional[dict]:
+    """Return a node by id."""
+    kb = load_kb()
+    return kb["nodes"].get(str(node_id))
+
+
+@mcp.tool()
+def neighbors(node_id: str, edge_type: Optional[str] = None, limit: int = 50) -> list[dict]:
+    """Return outgoing edges from a node. Optionally filter by edge_type."""
+    kb = load_kb()
+    outs = kb["adj"].get(str(node_id), [])
+    if edge_type:
+        outs = [e for e in outs if str(e.get("type") or e.get("edge_type") or "").lower() == edge_type.lower()]
+
+    # Use MAX_NEIGHBORS instead of MAX_TOPK
+    max_n = max(1, min(limit, MAX_NEIGHBORS))
+    return outs[:max_n]
+
+@mcp.tool()
+def focus_pack(query: str, depth: int = 1, limit: int = 5, max_rules: int = 3) -> dict:
+    """
+    Build an enriched task context bundle.
+
+    Compared to standard search:
+    - prioritizes rule-like chunks/files (CONTRACT, DoD, LIMITS)
+    - returns 'key_rules'
+    - returns 'recommended_reading_order'
+    """
+    kb = load_kb()
+
+    # Safety limits
+    depth = max(0, min(int(depth), 2))
+    limit = max(1, min(int(limit), MAX_TOPK))
+    max_rules = max(1, min(int(max_rules), 10))
+
+    # 1) Base search
+    hits = search_query(query, top_k=limit)
+    if not hits:
+        return {
+            "query": query,
+            "primary_nodes": [],
+            "related_nodes": [],
+            "chunks": [],
+            "files": [],
+            "key_rules": [],
+            "recommended_reading_order": [],
+        }
+
+    chunk_ids = [str(h["chunk_id"]) for h in hits if "chunk_id" in h]
+    base_score_map = {str(h["chunk_id"]): float(h.get("score", 0.0)) for h in hits if "chunk_id" in h}
+
+    # 2) Chunk -> Node mapping (using pre-built index)
+    primary_nodes_set = set()
+    for cid in chunk_ids:
+        nodes = kb["chunk_to_nodes"].get(cid, [])
+        primary_nodes_set.update(nodes)
+    primary_nodes = list(primary_nodes_set)
+
+    # 3) Graph expansion
+    related_nodes = set(primary_nodes)
+    frontier = list(primary_nodes)
+
+    for _ in range(depth):
+        new_frontier = []
+        for node_id in frontier:
+            for e in kb["adj"].get(node_id, []):
+                # Robust edge target extraction
+                target = str(e.get("target") or e.get("to") or e.get("dest") or e.get("dst") or "")
+                if target and target not in related_nodes:
+                    related_nodes.add(target)
+                    new_frontier.append(target)
+        frontier = new_frontier
+
+    # 4) Node -> Chunk expansion
+    related_chunks = set(chunk_ids)
+    for node_id in related_nodes:
+        node = kb["nodes"].get(node_id)
+        if node and node.get("chunk_id"):
+            related_chunks.add(str(node["chunk_id"]))
+
+    # 5) Collect chunk details and score with rule bonuses
+    scored_chunks_data: list[dict] = [] # Store {cid, final_score, rule_bonus, chunk_obj}
+    files = set()
+
+    for cid in related_chunks:
+        chunk = kb["chunks"].get(cid)
+        if not isinstance(chunk, dict):
+            continue
+
+        file_path = _extract_chunk_file_path(chunk)
+        if file_path:
+            files.add(file_path)
+
+        rule_bonus = _rule_bonus_for_chunk(chunk)
+        final_score = base_score_map.get(cid, 0.0) + rule_bonus
+
+        scored_chunks_data.append({
+            "cid": cid,
+            "final_score": final_score,
+            "rule_bonus": rule_bonus,
+            "chunk": chunk
+        })
+
+    # Sort by final score
+    scored_chunks_data.sort(key=lambda x: x["final_score"], reverse=True)
+
+    # Cap results to avoid context flooding (max 50 chunks)
+    chunks_sorted = [x["cid"] for x in scored_chunks_data][:50]
+
+    # 6) Pick top rule-like chunks
+    key_rules: list[dict] = []
+    for item in scored_chunks_data:
+        if item["rule_bonus"] <= 0:
+            continue
+
+        chunk = item["chunk"]
+        key_rules.append({
+            "chunk_id": item["cid"],
+            "score": item["final_score"],
+            "file_path": _extract_chunk_file_path(chunk),
+            "section": _extract_chunk_section(chunk),
+        })
+
+        if len(key_rules) >= max_rules:
+            break
+
+    # 7) Recommended reading order = rule chunks first, then high-score direct hits
+    recommended_files: list[str] = []
+    seen_files = set()
+
+    for rule in key_rules:
+        fp = rule.get("file_path")
+        if fp and fp not in seen_files:
+            recommended_files.append(fp)
+            seen_files.add(fp)
+
+    for cid in chunks_sorted:
+        chunk = kb["chunks"].get(cid)
+        if not isinstance(chunk, dict):
+            continue
+        fp = _extract_chunk_file_path(chunk)
+        if fp and fp not in seen_files:
+            recommended_files.append(fp)
+            seen_files.add(fp)
+
+    return {
+        "query": query,
+        "primary_nodes": primary_nodes,
+        "related_nodes": sorted(list(related_nodes)),
+        "chunks": chunks_sorted,
+        "files": sorted(files),
+        "key_rules": key_rules,
+        "recommended_reading_order": recommended_files,
+    }
+
+@mcp.tool()
+def explain_node(node_id: str) -> dict:
+    """
+    Deep dive into a specific node: returns definition, neighbors,
+    associated chunk content, and related files.
+    """
+    kb = load_kb()
+    node = kb["nodes"].get(str(node_id))
+    if not node:
+        return {"error": f"Node {node_id} not found"}
+
+    # Neighbors (direct access for speed)
+    out_edges = kb["adj"].get(str(node_id), [])[:20]
+
+    # Chunk context
+    chunk_info = {}
+    cid = node.get("chunk_id")
+    if cid:
+        chunk = kb["chunks"].get(str(cid))
+        if chunk:
+            chunk_info = {
+                "chunk_id": cid,
+                "text": _extract_chunk_text(chunk)[:2000], # Preview
+                "file_path": _extract_chunk_file_path(chunk),
+                "rule_bonus": _rule_bonus_for_chunk(chunk)
+            }
+
+    return {
+        "node": node,
+        "neighbors": out_edges,
+        "context": chunk_info
+    }
+
+@mcp.tool()
+def find_nodes(
+    category: Optional[str] = None,
+    tag: Optional[str] = None,
+    used_in: Optional[str] = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Filter nodes by metadata (if present).
+
+    Expects node payload to possibly contain fields like:
+    - category (str or list)
+    - tags (list[str])
+    - used_in (list[str] or str)
+    """
+    kb = load_kb()
+    out: list[dict] = []
+    cat = category.lower() if category else None
+    tg = tag.lower() if tag else None
+    ui = used_in.lower() if used_in else None
+
+    for n in kb["nodes"].values():
+        if not isinstance(n, dict):
+            continue
+
+        if cat:
+            v = n.get("category")
+            ok = (isinstance(v, str) and v.lower() == cat) or (isinstance(v, list) and any(str(x).lower() == cat for x in v))
+            if not ok:
+                continue
+
+        if tg:
+            v = n.get("tags") or []
+            if isinstance(v, str):
+                v = [v]
+            if not (isinstance(v, list) and any(str(x).lower() == tg for x in v)):
+                continue
+
+        if ui:
+            v = n.get("used_in") or []
+            if isinstance(v, str):
+                v = [v]
+            if not (isinstance(v, list) and any(str(x).lower() == ui for x in v)):
+                continue
+
+        out.append(n)
+        if len(out) >= _clamp_topk(limit):
+            break
+
+    return out
+
+
+DEFAULT_HOST = os.environ.get("MCP_HOST", "127.0.0.1")
+DEFAULT_PORT = int(os.environ.get("MCP_PORT", "8000"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CIC Graph MCP Server")
+    parser.add_argument("--sse", action="store_true", help="Run as SSE server")
+    parser.add_argument("--host", default=DEFAULT_HOST, help=f"SSE bind host (default: {DEFAULT_HOST}, env: MCP_HOST)")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"SSE bind port (default: {DEFAULT_PORT}, env: MCP_PORT)")
+    args = parser.parse_args()
+
+    if args.sse:
+        print(f"Starting SSE server on http://{args.host}:{args.port}")
+        mcp.run(transport="sse", host=args.host, port=args.port)
+    else:
+        mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -960,7 +960,9 @@ def main() -> None:
 
     if args.sse:
         print(f"Starting SSE server on http://{args.host}:{args.port}")
-        mcp.run(transport="sse", host=args.host, port=args.port)
+        mcp.settings.host = args.host
+        mcp.settings.port = args.port
+        mcp.run(transport="sse")
     else:
         mcp.run()
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -22,11 +22,14 @@ import os
 import pickle
 import re
 import argparse
+import numpy as np
+import faiss
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 
 from mcp.server.fastmcp import FastMCP
+from sentence_transformers import SentenceTransformer
 
 mcp = FastMCP("cic-graph")
 
@@ -38,6 +41,10 @@ CHUNKS_PKL = Path(os.environ.get("CHUNKS_PKL", str(DATA_DIR / "chunks.pkl")))
 NODES_PKL = Path(os.environ.get("NODES_PKL", str(DATA_DIR / "graph_nodes.pkl")))
 EDGES_PKL = Path(os.environ.get("EDGES_PKL", str(DATA_DIR / "graph_edges.pkl")))
 INVERTED_PKL = Path(os.environ.get("INVERTED_PKL", str(DATA_DIR / "inverted_index.pkl")))
+FAISS_INDEX = Path(os.environ.get("FAISS_INDEX", str(DATA_DIR / "faiss.index")))
+BM25_PKL = Path(os.environ.get("BM25_PKL", str(DATA_DIR / "bm25.pkl")))
+CHUNK_IDS_PKL = Path(os.environ.get("CHUNK_IDS_PKL", str(DATA_DIR / "chunk_ids.pkl")))
+MODEL_NAME_PKL = Path(os.environ.get("MODEL_NAME_PKL", str(DATA_DIR / "model_name.pkl")))
 
 # Limits and Configuration
 DEFAULT_TOPK = int(os.environ.get("TOPK", "10"))
@@ -189,6 +196,27 @@ def load_kb() -> dict[str, Any]:
         # legacy: inverted_index.pkl == {"inverted_index": {token: [...]}}
         inverted_index = inverted.get("inverted_index", inverted)
 
+    # Load FAISS index
+    faiss_idx = None
+    faiss_chunk_ids: list[str] = []
+    if FAISS_INDEX.exists() and CHUNK_IDS_PKL.exists():
+        faiss_idx = faiss.read_index(str(FAISS_INDEX))
+        with CHUNK_IDS_PKL.open("rb") as f:
+            faiss_chunk_ids = pickle.load(f)
+
+    # Load BM25 index
+    bm25 = None
+    if BM25_PKL.exists():
+        with BM25_PKL.open("rb") as f:
+            bm25 = pickle.load(f)
+
+    # Load embedding model (used for query encoding)
+    model_name = "paraphrase-multilingual-MiniLM-L12-v2"
+    if MODEL_NAME_PKL.exists():
+        with MODEL_NAME_PKL.open("rb") as f:
+            model_name = pickle.load(f)
+    embedding_model = SentenceTransformer(model_name) if faiss_idx is not None else None
+
     return {
         "chunks": chunks_by_id,
         "nodes": nodes_by_id,
@@ -196,6 +224,10 @@ def load_kb() -> dict[str, Any]:
         "adj": adj,
         "chunk_to_nodes": chunk_to_nodes,
         "inverted": inverted_index,
+        "faiss_index": faiss_idx,
+        "faiss_chunk_ids": faiss_chunk_ids,
+        "bm25": bm25,
+        "embedding_model": embedding_model,
     }
 
 
@@ -306,6 +338,18 @@ def kb_status() -> dict:
                 "mtime": INVERTED_PKL.stat().st_mtime if INVERTED_PKL.exists() else None,
                 "size": INVERTED_PKL.stat().st_size if INVERTED_PKL.exists() else None,
             },
+            "faiss": {
+                "path": str(FAISS_INDEX),
+                "exists": FAISS_INDEX.exists(),
+                "mtime": FAISS_INDEX.stat().st_mtime if FAISS_INDEX.exists() else None,
+                "size": FAISS_INDEX.stat().st_size if FAISS_INDEX.exists() else None,
+            },
+            "bm25": {
+                "path": str(BM25_PKL),
+                "exists": BM25_PKL.exists(),
+                "mtime": BM25_PKL.stat().st_mtime if BM25_PKL.exists() else None,
+                "size": BM25_PKL.stat().st_size if BM25_PKL.exists() else None,
+            },
         }
     }
 
@@ -365,88 +409,92 @@ def list_node_types() -> list[str]:
 
 @mcp.tool()
 def search_token(token: str, top_k: int = DEFAULT_TOPK) -> list[dict]:
-    """Search a single token in the inverted index.
+    """Lexical single-token search using BM25.
 
     Returns a list of {chunk_id, score}.
     """
     kb = load_kb()
-    t = token.strip().lower()
-    hits = kb["inverted"].get(t, [])
-    hits_sorted = sorted(
-        (h for h in hits if isinstance(h, dict) and "chunk_id" in h),
-        key=lambda x: float(x.get("score", 0.0)),
-        reverse=True,
-    )
-    return hits_sorted[:_clamp_topk(top_k)]
+    bm25 = kb.get("bm25")
+    chunk_ids = kb.get("faiss_chunk_ids", [])
+
+    if bm25 is None or not chunk_ids:
+        # fallback: inverted index
+        t = token.strip().lower()
+        hits = kb["inverted"].get(t, [])
+        hits_sorted = sorted(
+            (h for h in hits if isinstance(h, dict) and "chunk_id" in h),
+            key=lambda x: float(x.get("score", 0.0)),
+            reverse=True,
+        )
+        return hits_sorted[:_clamp_topk(top_k)]
+
+    scores = bm25.get_scores([token.strip().lower()])
+    indexed = [(chunk_ids[i], float(s)) for i, s in enumerate(scores) if s > 0.01]
+    indexed.sort(key=lambda x: x[1], reverse=True)
+    return [{"chunk_id": cid, "score": sc} for cid, sc in indexed[:_clamp_topk(top_k)]]
 
 
 @mcp.tool()
 def search_query(query: str, top_k: int = DEFAULT_TOPK, threshold: float = 0.0) -> list[dict]:
-    """Multi-token search using inverted index (simple OR + sum scores).
+    """Semantic search using FAISS + multilingual embeddings.
 
-    Returns ranked chunks: {chunk_id, score, matched_tokens, file_path, line_range}.
+    Returns ranked chunks: {chunk_id, score, file_path, line_range}.
+    Falls back to BM25 inverted index if FAISS is not available.
     """
     kb = load_kb()
-    tokens = _tokenize(query)
-    if not tokens:
-        return []
+    faiss_idx = kb.get("faiss_index")
+    model = kb.get("embedding_model")
+    chunk_ids = kb.get("faiss_chunk_ids", [])
 
-    scores: dict[str, float] = {}
-    matched: dict[str, set[str]] = {}
+    if faiss_idx is None or model is None or not chunk_ids:
+        # fallback: BM25 / inverted index
+        tokens = _tokenize(query)
+        if not tokens:
+            return []
+        scores: dict[str, float] = {}
+        matched: dict[str, set[str]] = {}
+        for t in tokens:
+            for h in kb["inverted"].get(t, []):
+                if not isinstance(h, dict):
+                    continue
+                cid = str(h.get("chunk_id", ""))
+                if not cid:
+                    continue
+                s = float(h.get("score", 0.0))
+                scores[cid] = scores.get(cid, 0.0) + s
+                matched.setdefault(cid, set()).add(t)
+        ranked = sorted([(c, s) for c, s in scores.items() if s >= threshold], key=lambda x: x[1], reverse=True)
+        results = []
+        for cid, sc in ranked[:_clamp_topk(top_k)]:
+            chunk = kb["chunks"].get(cid, {})
+            meta = chunk.get("metadata", {}) or {}
+            results.append({
+                "chunk_id": cid,
+                "score": sc,
+                "matched_tokens": sorted(matched.get(cid, set())),
+                "file_path": chunk.get("file_path") or meta.get("file_path"),
+                "line_range": _normalize_line_range(chunk.get("line_range") or meta.get("line_range")),
+            })
+        return results
 
-    for t in tokens:
-        for h in kb["inverted"].get(t, []):
-            if not isinstance(h, dict):
-                continue
-            cid = h.get("chunk_id")
-            if not cid:
-                continue
-            cid = str(cid)
-            s = float(h.get("score", 0.0))
-            scores[cid] = scores.get(cid, 0.0) + s
-            matched.setdefault(cid, set()).add(t)
-
-    # Filter by threshold and sort
-    ranked = [
-        (cid, sc) for cid, sc in scores.items()
-        if sc >= threshold
-    ]
-    ranked.sort(key=lambda kv: kv[1], reverse=True)
-    ranked = ranked[:_clamp_topk(top_k)]
+    query_vec = model.encode([query], normalize_embeddings=True).astype("float32")
+    k = _clamp_topk(top_k)
+    scores_arr, indices = faiss_idx.search(query_vec, k)
 
     results = []
-    for cid, sc in ranked:
+    for score, idx in zip(scores_arr[0], indices[0]):
+        if idx < 0 or float(score) < threshold:
+            continue
+        cid = chunk_ids[idx]
         chunk = kb["chunks"].get(cid, {})
-        # Extract metadata
-        meta = chunk.get("metadata", {})
-        if not isinstance(meta, dict):
-            meta = {}
-
-        # Try to find file path in various places
-        file_path = (
-            chunk.get("file_path") or
-            meta.get("file_path") or
-            chunk.get("path") or
-            meta.get("path")
-        )
-
-        # Try to find line range
-        raw_lines = (
-            chunk.get("line_range") or
-            meta.get("line_range") or
-            chunk.get("lines") or
-            meta.get("lines")
-        )
-        line_range = _normalize_line_range(raw_lines)
-
+        meta = chunk.get("metadata", {}) or {}
         results.append({
             "chunk_id": cid,
-            "score": sc,
-            "matched_tokens": sorted(matched.get(cid, set())),
-            "file_path": file_path,
-            "line_range": line_range,
+            "score": float(score),
+            "matched_tokens": [],
+            "file_path": chunk.get("file_path") or meta.get("file_path"),
+            "line_range": _normalize_line_range(chunk.get("line_range") or meta.get("line_range")),
         })
-
     return results
 
 

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -215,7 +215,13 @@ def load_kb() -> dict[str, Any]:
     if MODEL_NAME_PKL.exists():
         with MODEL_NAME_PKL.open("rb") as f:
             model_name = pickle.load(f)
-    embedding_model = SentenceTransformer(model_name) if faiss_idx is not None else None
+    if faiss_idx is not None:
+        try:
+            embedding_model = SentenceTransformer(model_name, local_files_only=True)
+        except Exception:
+            embedding_model = SentenceTransformer(model_name)
+    else:
+        embedding_model = None
 
     return {
         "chunks": chunks_by_id,
@@ -564,7 +570,7 @@ def search_code(code_snippet: str, top_k: int = DEFAULT_TOPK) -> list[dict]:
 
 
 @mcp.tool()
-def search_nodes(query: str, limit: int = 10) -> list[dict]:
+def search_nodes(query: str, top_k: int = DEFAULT_TOPK) -> list[dict]:
     """Search for nodes by name, label, type, or tags.
 
     Useful when you know the concept name but not the exact text content.
@@ -572,7 +578,7 @@ def search_nodes(query: str, limit: int = 10) -> list[dict]:
     kb = load_kb()
     q = query.lower().strip()
     results = []
-    limit = _clamp_topk(limit)
+    limit = _clamp_topk(top_k)
 
     for nid, node in kb["nodes"].items():
         if not isinstance(node, dict):
@@ -727,7 +733,7 @@ def neighbors(node_id: str, edge_type: Optional[str] = None, limit: int = 50) ->
     return outs[:max_n]
 
 @mcp.tool()
-def focus_pack(query: str, depth: int = 1, limit: int = 5, max_rules: int = 3) -> dict:
+def focus_pack(query: str, depth: int = 1, top_k: int = 5, max_rules: int = 3) -> dict:
     """
     Build an enriched task context bundle.
 
@@ -740,7 +746,7 @@ def focus_pack(query: str, depth: int = 1, limit: int = 5, max_rules: int = 3) -
 
     # Safety limits
     depth = max(0, min(int(depth), 2))
-    limit = max(1, min(int(limit), MAX_TOPK))
+    limit = max(1, min(int(top_k), MAX_TOPK))
     max_rules = max(1, min(int(max_rules), 10))
 
     # 1) Base search

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1167,22 +1167,30 @@ def guided_path(topic: str, max_steps: int = 10) -> dict:
 SOURCE_DIR = Path(os.environ.get("SOURCE_DIR", str(BASE_DIR / "source")))
 
 
+_COMPANION_LANGS = {
+    "go": {"glob": "*.go", "is_test": lambda name: "_test.go" in name},
+    "py": {"glob": "*.py", "is_test": lambda name: name.startswith("test_") or name.endswith("_test.py")},
+}
+
+
 @mcp.tool()
 def missing_companions(
     source_dir: str = "",
+    langs: Optional[list[str]] = None,
     include_empty_semantic: bool = True,
     limit: int = 50,
 ) -> dict:
-    """List Go source files that lack a companion YAML or have empty semantic fields.
+    """List Go/Python source files that lack a companion YAML or have empty semantic fields.
 
-    Scans the source directory for .go files and reports:
-    - 'missing': .go files with no companion .yaml at all
+    Scans the source directory for .go and .py files (per `langs`) and reports:
+    - 'missing': source files with no companion .yaml at all
     - 'incomplete': companion YAMLs exist but category/used_in/related_nodes are all empty
 
     Results are sorted by file size descending (larger = higher priority).
 
     Args:
         source_dir: Override the scan root (default: SOURCE_DIR env or source/).
+        langs: Which source languages to scan. Default: ["go", "py"].
         include_empty_semantic: Also report companions with no semantic fields filled.
         limit: Max entries per category (default 50).
     """
@@ -1192,36 +1200,46 @@ def missing_companions(
     if not scan_root.exists():
         return {"error": f"source_dir not found: {scan_root}"}
 
+    selected = langs or list(_COMPANION_LANGS)
+    unknown = [lang for lang in selected if lang not in _COMPANION_LANGS]
+    if unknown:
+        return {"error": f"unknown lang(s): {unknown}. allowed: {list(_COMPANION_LANGS)}"}
+
     missing: list[dict] = []
     incomplete: list[dict] = []
 
-    for go_file in sorted(scan_root.rglob("*.go")):
-        if "_test.go" in go_file.name:
-            continue
-        companion = go_file.with_suffix(".yaml")
-        rel = str(go_file.relative_to(scan_root))
-        size = go_file.stat().st_size
+    for lang in selected:
+        spec = _COMPANION_LANGS[lang]
+        for src_file in sorted(scan_root.rglob(spec["glob"])):
+            if spec["is_test"](src_file.name):
+                continue
+            companion = src_file.with_suffix(".yaml")
+            rel = str(src_file.relative_to(scan_root))
+            size = src_file.stat().st_size
 
-        if not companion.exists():
-            missing.append({"file": rel, "size": size})
-            continue
+            if not companion.exists():
+                missing.append({"file": rel, "lang": lang, "size": size})
+                continue
 
-        if not include_empty_semantic:
-            continue
+            if not include_empty_semantic:
+                continue
 
-        try:
-            with companion.open() as f:
-                data = _yaml.safe_load(f) or {}
-        except Exception:
-            continue
+            try:
+                with companion.open() as f:
+                    data = _yaml.safe_load(f) or {}
+            except Exception:
+                continue
 
-        cat = data.get("category") or []
-        used = data.get("used_in") or []
-        related = data.get("related_nodes") or []
-        desc = (data.get("description") or "").strip()
+            cat = data.get("category") or []
+            used = data.get("used_in") or []
+            related = data.get("related_nodes") or []
+            desc = (data.get("description") or "").strip()
 
-        if not cat and not used and not related and not desc:
-            incomplete.append({"file": rel, "companion": str(companion.relative_to(scan_root)), "size": size})
+            if not cat and not used and not related and not desc:
+                incomplete.append({
+                    "file": rel, "lang": lang,
+                    "companion": str(companion.relative_to(scan_root)), "size": size,
+                })
 
     missing.sort(key=lambda x: -x["size"])
     incomplete.sort(key=lambda x: -x["size"])

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -259,17 +259,28 @@ def _extract_chunk_text(chunk: dict) -> str:
     return ""
 
 
-def _extract_chunk_file_path(chunk: dict) -> str:
+def _extract_chunk_file_paths(chunk: dict) -> list[str]:
+    """Return all file paths for a chunk (dedup-aware: file_paths list)."""
+    fps = chunk.get("file_paths")
+    if isinstance(fps, list) and fps:
+        return [str(p) for p in fps if p]
     meta = chunk.get("metadata", {})
     if not isinstance(meta, dict):
         meta = {}
-    return str(
+    single = (
         chunk.get("file_path")
         or meta.get("file_path")
         or chunk.get("path")
         or meta.get("path")
         or ""
     )
+    return [str(single)] if single else []
+
+
+def _extract_chunk_file_path(chunk: dict) -> str:
+    """Return the canonical (primary) file path for a chunk."""
+    paths = _extract_chunk_file_paths(chunk)
+    return paths[0] if paths else ""
 
 
 def _extract_chunk_section(chunk: dict) -> str:
@@ -480,7 +491,7 @@ def search_query(query: str, top_k: int = DEFAULT_TOPK, threshold: float = 0.0) 
                 "chunk_id": cid,
                 "score": sc,
                 "matched_tokens": sorted(matched.get(cid, set())),
-                "file_path": chunk.get("file_path") or meta.get("file_path"),
+                "file_paths": _extract_chunk_file_paths(chunk),
                 "line_range": _normalize_line_range(chunk.get("line_range") or meta.get("line_range")),
             })
         return results
@@ -500,7 +511,7 @@ def search_query(query: str, top_k: int = DEFAULT_TOPK, threshold: float = 0.0) 
             "chunk_id": cid,
             "score": float(score),
             "matched_tokens": [],
-            "file_path": chunk.get("file_path") or meta.get("file_path"),
+            "file_paths": _extract_chunk_file_paths(chunk),
             "line_range": _normalize_line_range(chunk.get("line_range") or meta.get("line_range")),
         })
     return results
@@ -562,7 +573,7 @@ def search_code(code_snippet: str, top_k: int = DEFAULT_TOPK) -> list[dict]:
             results.append({
                 "chunk_id": cid,
                 "preview": preview,
-                "file_path": file_path,
+                "file_paths": _extract_chunk_file_paths(chunk),
                 "line_range": line_range
             })
             if len(results) >= limit:
@@ -669,24 +680,21 @@ def resolve_path(file_path: str, mode: str = "prefix", limit: int = 200) -> list
         if not isinstance(meta, dict):
             meta = {}
 
-        # Check path match
-        path_raw = (
-            chunk.get("file_path") or
-            meta.get("file_path") or
-            chunk.get("path") or
-            meta.get("path") or ""
-        )
-        path_str = str(path_raw).lower()
+        # Check against all paths (dedup-aware)
+        all_paths = _extract_chunk_file_paths(chunk)
+        matched_paths = []
+        for path_raw in all_paths:
+            path_str = path_raw.lower()
+            if mode == "exact":
+                hit = (path_str == target)
+            elif mode == "contains":
+                hit = (target in path_str)
+            else:  # prefix (default)
+                hit = path_str.startswith(target)
+            if hit:
+                matched_paths.append(path_raw)
 
-        match = False
-        if mode == "exact":
-            match = (path_str == target)
-        elif mode == "contains":
-            match = (target in path_str)
-        else: # prefix (default)
-            match = path_str.startswith(target)
-
-        if match:
+        if matched_paths:
             raw_lines = (
                 chunk.get("line_range") or
                 meta.get("line_range") or
@@ -697,8 +705,9 @@ def resolve_path(file_path: str, mode: str = "prefix", limit: int = 200) -> list
 
             results.append({
                 "chunk_id": cid,
-                "file_path": path_raw,
-                "line_range": line_range
+                "file_paths": all_paths,
+                "matched_paths": matched_paths,
+                "line_range": line_range,
             })
 
             if len(results) >= max_res:
@@ -974,6 +983,640 @@ def find_nodes(
             if len(out) >= limit:
                 return out
     return out
+
+
+@mcp.tool()
+def impact_analysis(node_id: str, max_depth: int = 3) -> dict:
+    """Analyse the downstream impact of a node: what depends on it, critical paths, used_in coverage.
+
+    Performs BFS from node_id through the adjacency graph, collects all reachable downstream
+    nodes, aggregates used_in fields, and identifies critical path nodes (highest fan-out).
+
+    Args:
+        node_id: The node to start from.
+        max_depth: BFS depth limit (default 3, max 5).
+    """
+    kb = load_kb()
+    nodes = kb["nodes"]
+    adj = kb["adj"]
+
+    max_depth = max(1, min(int(max_depth), 5))
+    start = str(node_id)
+
+    if start not in nodes:
+        return {"error": f"node '{node_id}' not found"}
+
+    # BFS
+    visited: dict[str, int] = {start: 0}   # node_id -> depth
+    queue: list[tuple[str, int]] = [(start, 0)]
+    fan_out: dict[str, int] = {}             # node_id -> number of direct children found
+
+    while queue:
+        current, depth = queue.pop(0)
+        if depth >= max_depth:
+            continue
+        edges = adj.get(current, [])
+        fan_out[current] = len(edges)
+        for edge in edges:
+            target = str(edge.get("target") or edge.get("to") or edge.get("dest") or edge.get("dst") or "")
+            if not target or target in visited:
+                continue
+            visited[target] = depth + 1
+            queue.append((target, depth + 1))
+
+    # Collect used_in from all visited nodes
+    used_in_agg: dict[str, list[str]] = {}
+    downstream: list[dict] = []
+    for nid, depth in visited.items():
+        if nid == start:
+            continue
+        node = nodes.get(nid)
+        if not isinstance(node, dict):
+            continue
+        entry = {
+            "node_id": nid,
+            "label": node.get("label", nid),
+            "type": node.get("type", ""),
+            "depth": depth,
+            "chunk_id": node.get("chunk_id", ""),
+        }
+        downstream.append(entry)
+        for ui in node.get("used_in") or []:
+            used_in_agg.setdefault(str(ui), []).append(nid)
+
+    # Critical path: nodes with highest fan-out (excluding start)
+    critical = sorted(
+        [{"node_id": nid, "fan_out": fo, "label": nodes.get(nid, {}).get("label", nid)}
+         for nid, fo in fan_out.items() if nid != start and fo > 0],
+        key=lambda x: x["fan_out"],
+        reverse=True,
+    )[:10]
+
+    return {
+        "node_id": start,
+        "label": nodes.get(start, {}).get("label", start),
+        "total_downstream": len(downstream),
+        "max_depth_reached": max(visited.values()) if visited else 0,
+        "downstream": downstream,
+        "used_in_coverage": {k: v for k, v in sorted(used_in_agg.items(), key=lambda x: -len(x[1]))},
+        "critical_paths": critical,
+    }
+
+
+@mcp.tool()
+def guided_path(topic: str, max_steps: int = 10) -> dict:
+    """Build an ordered learning path for a topic through the knowledge graph.
+
+    Selects entrypoint nodes matching the topic, then traverses the graph in
+    category priority order (concept → architecture → flow → implementation)
+    to return a structured reading sequence.
+
+    Args:
+        topic: The topic or concept to learn about.
+        max_steps: Maximum nodes in the path (default 10, max 20).
+    """
+    kb = load_kb()
+    nodes = kb["nodes"]
+    adj = kb["adj"]
+    chunk_to_nodes = kb.get("chunk_to_nodes", {})
+
+    max_steps = max(1, min(int(max_steps), 20))
+
+    CATEGORY_PRIORITY = ["concept", "architecture", "flow", "implementation", "spec", "config", "test"]
+
+    def _cat_rank(node: dict) -> int:
+        cats = node.get("category") or []
+        if isinstance(cats, str):
+            cats = [cats]
+        for i, c in enumerate(CATEGORY_PRIORITY):
+            if any(c in str(cat).lower() for cat in cats):
+                return i
+        return len(CATEGORY_PRIORITY)
+
+    # 1) Find candidates via search
+    hits = search_query(topic, top_k=20)
+    candidate_node_ids: list[str] = []
+    seen_chunks: set[str] = set()
+    for h in hits:
+        cid = str(h.get("chunk_id", ""))
+        if not cid or cid in seen_chunks:
+            continue
+        seen_chunks.add(cid)
+        for nid in chunk_to_nodes.get(cid, []):
+            if nid not in candidate_node_ids:
+                candidate_node_ids.append(nid)
+
+    if not candidate_node_ids:
+        return {"topic": topic, "path": [], "note": "no nodes found for topic"}
+
+    # 2) Prefer entrypoints as starting nodes
+    entrypoints = [nid for nid in candidate_node_ids if nodes.get(nid, {}).get("entrypoint")]
+    start_pool = entrypoints if entrypoints else candidate_node_ids[:5]
+
+    # Sort start_pool by category priority
+    start_pool = sorted(start_pool, key=lambda nid: _cat_rank(nodes.get(nid, {})))
+    start = start_pool[0]
+
+    # 3) BFS guided by category priority
+    path: list[dict] = []
+    visited: set[str] = set()
+    queue: list[tuple[str, str]] = [(start, "entrypoint — best match for topic")]
+
+    while queue and len(path) < max_steps:
+        current, reason = queue.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+
+        node = nodes.get(current)
+        if not isinstance(node, dict):
+            continue
+
+        path.append({
+            "node_id": current,
+            "label": node.get("label", current),
+            "type": node.get("type", ""),
+            "category": node.get("category", []),
+            "chunk_id": node.get("chunk_id", ""),
+            "entrypoint": bool(node.get("entrypoint")),
+            "reason": reason,
+        })
+
+        # Expand neighbours, prioritise by category rank
+        edges = adj.get(current, [])
+        children: list[tuple[str, str]] = []
+        for edge in edges:
+            target = str(edge.get("target") or edge.get("to") or edge.get("dest") or edge.get("dst") or "")
+            if not target or target in visited:
+                continue
+            edge_type = str(edge.get("type") or edge.get("edge_type") or "related")
+            children.append((target, f"via {edge_type} from {node.get('label', current)}"))
+
+        # Sort children by category priority
+        children.sort(key=lambda x: _cat_rank(nodes.get(x[0], {})))
+        queue = children + queue   # depth-first within priority
+
+    return {
+        "topic": topic,
+        "start_node": start,
+        "entrypoints_found": len(entrypoints),
+        "path": path,
+    }
+
+
+SOURCE_DIR = Path(os.environ.get("SOURCE_DIR", str(BASE_DIR / "source")))
+
+
+@mcp.tool()
+def missing_companions(
+    source_dir: str = "",
+    include_empty_semantic: bool = True,
+    limit: int = 50,
+) -> dict:
+    """List Go source files that lack a companion YAML or have empty semantic fields.
+
+    Scans the source directory for .go files and reports:
+    - 'missing': .go files with no companion .yaml at all
+    - 'incomplete': companion YAMLs exist but category/used_in/related_nodes are all empty
+
+    Results are sorted by file size descending (larger = higher priority).
+
+    Args:
+        source_dir: Override the scan root (default: SOURCE_DIR env or source/).
+        include_empty_semantic: Also report companions with no semantic fields filled.
+        limit: Max entries per category (default 50).
+    """
+    import yaml as _yaml
+
+    scan_root = Path(source_dir) if source_dir else SOURCE_DIR
+    if not scan_root.exists():
+        return {"error": f"source_dir not found: {scan_root}"}
+
+    missing: list[dict] = []
+    incomplete: list[dict] = []
+
+    for go_file in sorted(scan_root.rglob("*.go")):
+        if "_test.go" in go_file.name:
+            continue
+        companion = go_file.with_suffix(".yaml")
+        rel = str(go_file.relative_to(scan_root))
+        size = go_file.stat().st_size
+
+        if not companion.exists():
+            missing.append({"file": rel, "size": size})
+            continue
+
+        if not include_empty_semantic:
+            continue
+
+        try:
+            with companion.open() as f:
+                data = _yaml.safe_load(f) or {}
+        except Exception:
+            continue
+
+        cat = data.get("category") or []
+        used = data.get("used_in") or []
+        related = data.get("related_nodes") or []
+        desc = (data.get("description") or "").strip()
+
+        if not cat and not used and not related and not desc:
+            incomplete.append({"file": rel, "companion": str(companion.relative_to(scan_root)), "size": size})
+
+    missing.sort(key=lambda x: -x["size"])
+    incomplete.sort(key=lambda x: -x["size"])
+
+    return {
+        "scan_root": str(scan_root),
+        "missing_count": len(missing),
+        "incomplete_count": len(incomplete),
+        "missing": missing[:limit],
+        "incomplete": incomplete[:limit],
+    }
+
+
+# PROMPTMAP_PATHS: colon-separated list of absolute paths to PROMPTMAP.yaml files.
+# If not set, the tools scan SOURCE_DIR recursively.
+_PROMPTMAP_PATHS_ENV = os.environ.get("PROMPTMAP_PATHS", "")
+
+
+def _find_promptmaps() -> list[Path]:
+    """Return all known PROMPTMAP.yaml paths (env override or source dir scan)."""
+    if _PROMPTMAP_PATHS_ENV:
+        return [Path(p) for p in _PROMPTMAP_PATHS_ENV.split(":") if p.strip()]
+    return list(SOURCE_DIR.rglob("PROMPTMAP.yaml"))
+
+
+def _load_promptmap(path: Path) -> dict:
+    import yaml as _yaml
+    with path.open() as f:
+        return _yaml.safe_load(f) or {}
+
+
+def _save_promptmap(path: Path, data: dict) -> None:
+    import yaml as _yaml
+    with path.open("w") as f:
+        _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+
+def _promptmap_repo_name(path: Path) -> str:
+    """Derive a short repo name from PROMPTMAP path (parent directory names)."""
+    parts = path.parts
+    try:
+        ai_idx = list(parts).index("ai")
+        return parts[ai_idx - 1] if ai_idx > 0 else path.parent.parent.name
+    except ValueError:
+        return path.parent.parent.name
+
+
+def _iter_tasks(data: dict, sprint: Optional[int] = None):
+    """Yield (sprint_num, task_dict) pairs from a PROMPTMAP data structure."""
+    version = data.get("version", 1)
+    if version >= 2:
+        # v2: top-level entries list + sprint blocks
+        for entry in data.get("entries", []):
+            yield None, entry
+        for block in data.get("sprints", []):
+            snum = block.get("sprint")
+            for task in block.get("tasks", []):
+                if sprint is None or snum == sprint:
+                    yield snum, task
+        # v2 can also have top-level sprint + tasks (single sprint file)
+        if "sprint" in data and "tasks" in data:
+            snum = data["sprint"]
+            for task in data["tasks"]:
+                if sprint is None or snum == sprint:
+                    yield snum, task
+    else:
+        for task in data.get("tasks", []):
+            yield None, task
+
+
+@mcp.tool()
+def list_tasks(
+    repo: str = "",
+    sprint: Optional[int] = None,
+    status: Optional[str] = None,
+) -> list[dict]:
+    """List tasks from PROMPTMAP.yaml files.
+
+    Args:
+        repo: Filter by repo name substring (e.g. 'CIC-Relay'). Empty = all repos.
+        sprint: Filter by sprint number. None = all sprints.
+        status: Filter by status ('todo', 'done', 'in_progress', 'failed'). None = all.
+
+    Returns list of dicts with keys: repo, sprint, task, status, priority, prompt (truncated).
+    """
+    results = []
+    for pm_path in _find_promptmaps():
+        repo_name = _promptmap_repo_name(pm_path)
+        if repo and repo.lower() not in repo_name.lower():
+            continue
+        try:
+            data = _load_promptmap(pm_path)
+        except Exception as e:
+            results.append({"repo": repo_name, "error": str(e)})
+            continue
+        for snum, task in _iter_tasks(data, sprint):
+            if not isinstance(task, dict):
+                continue
+            task_status = task.get("status", "")
+            if status and task_status != status:
+                continue
+            prompt_text = str(task.get("prompt", ""))
+            results.append({
+                "repo": repo_name,
+                "sprint": snum,
+                "task": task.get("task", ""),
+                "status": task_status,
+                "priority": task.get("priority"),
+                "milestone": task.get("milestone"),
+                "prompt": prompt_text[:200] + "..." if len(prompt_text) > 200 else prompt_text,
+                "accept": task.get("accept", ""),
+                "tests": task.get("tests", []),
+            })
+    results.sort(key=lambda x: (x.get("priority") is None, x.get("priority") or 0))
+    return results
+
+
+@mcp.tool()
+def get_next_task(repo: str = "", sprint: Optional[int] = None) -> Optional[dict]:
+    """Return the highest-priority todo task from PROMPTMAP files.
+
+    Args:
+        repo: Filter by repo name substring.
+        sprint: Filter by sprint number. None = any sprint.
+
+    Returns the full task dict (with prompt, tests, accept) or None if no todo tasks found.
+    """
+    tasks = list_tasks(repo=repo, sprint=sprint, status="todo")
+    if not tasks:
+        return None
+    # Already sorted by priority
+    t = tasks[0]
+    # Re-read full prompt (list_tasks truncates it)
+    for pm_path in _find_promptmaps():
+        repo_name = _promptmap_repo_name(pm_path)
+        if t["repo"] != repo_name:
+            continue
+        try:
+            data = _load_promptmap(pm_path)
+        except Exception:
+            continue
+        for snum, task in _iter_tasks(data):
+            if task.get("task") == t["task"] and task.get("status") == "todo":
+                return {
+                    "repo": repo_name,
+                    "sprint": snum,
+                    **{k: v for k, v in task.items()},
+                }
+    return t
+
+
+def _update_task_status(pm_path: Path, task_id: str, new_status: str, extra: Optional[dict] = None) -> bool:
+    """Mutate a task's status in a PROMPTMAP file. Returns True if found and saved."""
+    import yaml as _yaml
+    data = _load_promptmap(pm_path)
+    found = False
+
+    def _patch(task: dict) -> None:
+        nonlocal found
+        if task.get("task") == task_id:
+            task["status"] = new_status
+            if extra:
+                task.update(extra)
+            found = True
+
+    for entry in data.get("entries", []):
+        if isinstance(entry, dict):
+            _patch(entry)
+    for block in data.get("sprints", []):
+        for task in block.get("tasks", []):
+            if isinstance(task, dict):
+                _patch(task)
+    if "tasks" in data:
+        for task in data["tasks"]:
+            if isinstance(task, dict):
+                _patch(task)
+
+    if found:
+        _save_promptmap(pm_path, data)
+    return found
+
+
+@mcp.tool()
+def claim_task(task_id: str, repo: str = "") -> dict:
+    """Mark a task as in_progress in the PROMPTMAP.
+
+    Args:
+        task_id: The task identifier string (e.g. 'upstream-source-http').
+        repo: Repo name substring to narrow the search (optional).
+
+    Returns: {success, repo, task_id, message}
+    """
+    for pm_path in _find_promptmaps():
+        repo_name = _promptmap_repo_name(pm_path)
+        if repo and repo.lower() not in repo_name.lower():
+            continue
+        if _update_task_status(pm_path, task_id, "in_progress"):
+            return {"success": True, "repo": repo_name, "task_id": task_id, "message": "status → in_progress"}
+    return {"success": False, "task_id": task_id, "message": "task not found"}
+
+
+@mcp.tool()
+def complete_task(task_id: str, repo: str = "", result_note: str = "") -> dict:
+    """Mark a task as done in the PROMPTMAP.
+
+    Args:
+        task_id: The task identifier string.
+        repo: Repo name substring to narrow the search (optional).
+        result_note: Short summary of what was done (stored as 'result' field).
+
+    Returns: {success, repo, task_id, message}
+    """
+    extra = {"result": result_note} if result_note else None
+    for pm_path in _find_promptmaps():
+        repo_name = _promptmap_repo_name(pm_path)
+        if repo and repo.lower() not in repo_name.lower():
+            continue
+        if _update_task_status(pm_path, task_id, "done", extra):
+            return {"success": True, "repo": repo_name, "task_id": task_id, "message": "status → done"}
+    return {"success": False, "task_id": task_id, "message": "task not found"}
+
+
+@mcp.tool()
+def fail_task(task_id: str, reason: str, repo: str = "") -> dict:
+    """Mark a task as failed in the PROMPTMAP with a reason.
+
+    Args:
+        task_id: The task identifier string.
+        reason: Why it failed (stored as 'failure_reason' field).
+        repo: Repo name substring to narrow the search (optional).
+
+    Returns: {success, repo, task_id, message}
+    """
+    for pm_path in _find_promptmaps():
+        repo_name = _promptmap_repo_name(pm_path)
+        if repo and repo.lower() not in repo_name.lower():
+            continue
+        if _update_task_status(pm_path, task_id, "failed", {"failure_reason": reason}):
+            return {"success": True, "repo": repo_name, "task_id": task_id, "message": "status → failed"}
+    return {"success": False, "task_id": task_id, "message": "task not found"}
+
+
+@mcp.tool()
+def update_companion(
+    file_path: str,
+    description: str = "",
+    category: Optional[list] = None,
+    used_in: Optional[list] = None,
+    related_nodes: Optional[list] = None,
+    tags: Optional[list] = None,
+) -> dict:
+    """Update semantic fields in a companion YAML file (Go meta companion).
+
+    Only updates fields that are explicitly provided (non-empty/non-None).
+    Auto-generated fields (package, objects, references) are never touched.
+    After updating, the file must be committed (Vault Transit hook signs it automatically).
+
+    Args:
+        file_path: Absolute path or path relative to SOURCE_DIR to the companion .yaml.
+        description: Package-level description (replaces empty description only if provided).
+        category: List of category tags (replaces existing list if provided).
+        used_in: List of usage contexts (replaces existing list if provided).
+        related_nodes: List of related node IDs (replaces existing list if provided).
+        tags: List of keyword tags (replaces existing list if provided).
+
+    Returns: {success, path, updated_fields, message}
+    """
+    import yaml as _yaml
+
+    p = Path(file_path)
+    if not p.is_absolute():
+        p = SOURCE_DIR / file_path
+    if not p.exists():
+        return {"success": False, "path": str(p), "message": "file not found"}
+
+    try:
+        with p.open() as f:
+            data = _yaml.safe_load(f) or {}
+    except Exception as e:
+        return {"success": False, "path": str(p), "message": f"parse error: {e}"}
+
+    updated: list[str] = []
+
+    if description:
+        data["description"] = description
+        updated.append("description")
+    if category is not None:
+        data["category"] = category
+        updated.append("category")
+    if used_in is not None:
+        data["used_in"] = used_in
+        updated.append("used_in")
+    if related_nodes is not None:
+        data["related_nodes"] = related_nodes
+        updated.append("related_nodes")
+    if tags is not None:
+        data["tags"] = tags
+        updated.append("tags")
+
+    if not updated:
+        return {"success": False, "path": str(p), "message": "no fields to update provided"}
+
+    try:
+        with p.open("w") as f:
+            _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+    except Exception as e:
+        return {"success": False, "path": str(p), "message": f"write error: {e}"}
+
+    return {
+        "success": True,
+        "path": str(p),
+        "updated_fields": updated,
+        "message": f"Updated {len(updated)} field(s). Commit to trigger Vault Transit signing.",
+    }
+
+
+@mcp.tool()
+def record_decision(
+    node_id: str,
+    decision: str,
+    rationale: str = "",
+    companion_path: str = "",
+) -> dict:
+    """Record an agent decision as a note in a companion YAML or standalone decision file.
+
+    Appends a decision entry to the companion YAML's 'agent_decisions' list.
+    If no companion_path given, tries to find the companion by node_id lookup.
+
+    Args:
+        node_id: KB node ID this decision relates to.
+        decision: Short statement of the decision made.
+        rationale: Why this decision was made (optional).
+        companion_path: Explicit path to companion YAML. If empty, resolved from node_id.
+
+    Returns: {success, path, message}
+    """
+    import yaml as _yaml
+    from datetime import datetime, timezone
+
+    kb = load_kb()
+
+    # Resolve companion path from node if not given
+    p: Optional[Path] = None
+    if companion_path:
+        p = Path(companion_path)
+        if not p.is_absolute():
+            p = SOURCE_DIR / companion_path
+    else:
+        node = kb["nodes"].get(str(node_id))
+        if node:
+            src = node.get("source_file") or node.get("file_path") or ""
+            if src:
+                candidate = Path(src).with_suffix(".yaml")
+                if candidate.exists():
+                    p = candidate
+                else:
+                    candidate2 = SOURCE_DIR / src
+                    candidate2 = candidate2.with_suffix(".yaml")
+                    if candidate2.exists():
+                        p = candidate2
+
+    if p is None or not p.exists():
+        return {
+            "success": False,
+            "node_id": node_id,
+            "message": "companion file not found — provide companion_path explicitly",
+        }
+
+    try:
+        with p.open() as f:
+            data = _yaml.safe_load(f) or {}
+    except Exception as e:
+        return {"success": False, "path": str(p), "message": f"parse error: {e}"}
+
+    decisions = data.setdefault("agent_decisions", [])
+    entry: dict = {
+        "node_id": node_id,
+        "decision": decision,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    if rationale:
+        entry["rationale"] = rationale
+    decisions.append(entry)
+
+    try:
+        with p.open("w") as f:
+            _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+    except Exception as e:
+        return {"success": False, "path": str(p), "message": f"write error: {e}"}
+
+    return {
+        "success": True,
+        "path": str(p),
+        "message": f"Decision recorded in agent_decisions[{len(decisions)-1}]. Commit to persist.",
+    }
 
 
 DEFAULT_HOST = os.environ.get("MCP_HOST", "127.0.0.1")

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -44,7 +44,7 @@ mcp = FastMCP("cic-graph")
 
 # Adjust paths to point to the correct location relative to this script
 BASE_DIR = Path(__file__).parent.parent
-DATA_DIR = Path(os.environ.get("KB_DATA_DIR", str(BASE_DIR / "kb_data" / "pkl")))
+DATA_DIR = Path(os.environ.get("KB_DATA_DIR", str(Path.cwd() / "kb_data" / "pkl")))
 
 CHUNKS_PKL = Path(os.environ.get("CHUNKS_PKL", str(DATA_DIR / "chunks.pkl")))
 NODES_PKL = Path(os.environ.get("NODES_PKL", str(DATA_DIR / "graph_nodes.pkl")))
@@ -1380,7 +1380,7 @@ def guided_path(topic: str, max_steps: int = 10) -> dict:
     }
 
 
-SOURCE_DIR = Path(os.environ.get("SOURCE_DIR", str(BASE_DIR / "source")))
+SOURCE_DIR = Path(os.environ.get("SOURCE_DIR", str(Path.cwd())))
 
 
 _COMPANION_LANGS = {
@@ -1865,8 +1865,8 @@ def main() -> None:
     parser.add_argument("--host", default=DEFAULT_HOST, help=f"SSE bind host (default: {DEFAULT_HOST}, env: MCP_HOST)")
     parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"SSE bind port (default: {DEFAULT_PORT}, env: MCP_PORT)")
     parser.add_argument("--watch-dir", metavar="DIR",
-                        default=os.environ.get("KB_WATCH_DIR"),
-                        help="Watch this directory for file changes and update KB in-memory (env: KB_WATCH_DIR)")
+                        default=os.environ.get("KB_WATCH_DIR", str(Path.cwd())),
+                        help="Watch this directory for file changes and update KB in-memory (default: cwd, env: KB_WATCH_DIR)")
     parser.add_argument("--watch-interval", type=float, default=float(os.environ.get("KB_WATCH_INTERVAL", "2")),
                         help="Poll interval for --watch-dir in seconds (default: 2, env: KB_WATCH_INTERVAL)")
     args = parser.parse_args()

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -22,14 +22,23 @@ import os
 import pickle
 import re
 import argparse
+import hashlib
+import json
+import threading
+import time
 import numpy as np
 import faiss
-from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 
 from mcp.server.fastmcp import FastMCP
 from sentence_transformers import SentenceTransformer
+
+# ── watch-mode globals ───────────────────────────────────────────────────────
+_kb: dict | None = None
+_kb_lock = threading.RLock()
+_watch_dir: Path | None = None
+_watch_interval: float = 2.0
 
 mcp = FastMCP("cic-graph")
 
@@ -95,19 +104,33 @@ def _normalize_line_range(val: Any) -> Optional[list[int]]:
     return None
 
 
-@lru_cache(maxsize=1)
 def load_kb() -> dict[str, Any]:
-    """Load all PKL artifacts into memory once."""
+    """Return the in-memory KB, loading from disk on first call."""
+    global _kb
+    with _kb_lock:
+        if _kb is None:
+            _kb = _load_kb_from_disk()
+        return _kb
+
+
+def _load_kb_from_disk() -> dict[str, Any]:
+    """Load all PKL artifacts from disk into a fresh dict."""
     def load_one(p: Path) -> Any:
         if not p.exists():
             raise FileNotFoundError(f"Missing: {p}")
         with p.open("rb") as f:
             return pickle.load(f)
 
+    def load_opt(p: Path, default: Any = None) -> Any:
+        if not p.exists():
+            return default
+        with p.open("rb") as f:
+            return pickle.load(f)
+
     chunks = load_one(CHUNKS_PKL)
-    nodes = load_one(NODES_PKL)
-    edges = load_one(EDGES_PKL)
-    inverted = load_one(INVERTED_PKL)
+    nodes = load_opt(NODES_PKL, {})
+    edges = load_opt(EDGES_PKL, {})
+    inverted = load_opt(INVERTED_PKL, {})
 
     # Normalize chunks container:
     # Supported:
@@ -224,6 +247,15 @@ def load_kb() -> dict[str, Any]:
     else:
         embedding_model = None
 
+    # Build embeddings_by_id from FAISS vectors — needed for incremental watch updates
+    embeddings_by_id: dict[str, np.ndarray] = {}
+    if faiss_idx is not None:
+        for i, cid in enumerate(faiss_chunk_ids):
+            try:
+                embeddings_by_id[str(cid)] = faiss_idx.reconstruct(i)
+            except Exception:
+                pass
+
     return {
         "chunks": chunks_by_id,
         "nodes": nodes_by_id,
@@ -233,6 +265,7 @@ def load_kb() -> dict[str, Any]:
         "inverted": inverted_index,
         "faiss_index": faiss_idx,
         "faiss_chunk_ids": faiss_chunk_ids,
+        "embeddings_by_id": embeddings_by_id,
         "bm25": bm25,
         "embedding_model": embedding_model,
         "meta_idx": load_one(METADATA_INDEX_PKL) if METADATA_INDEX_PKL.exists() else {},
@@ -329,9 +362,13 @@ def _kb_mtimes() -> dict[str, float | None]:
 @mcp.tool()
 def kb_status() -> dict:
     """Return detailed status about loaded KB artifacts."""
+    kb = load_kb()
     return {
         "data_dir": str(DATA_DIR),
-        "cache_info": load_kb.cache_info()._asdict(),
+        "kb_loaded": _kb is not None,
+        "watch_dir": str(_watch_dir) if _watch_dir else None,
+        "chunks": len(kb.get("chunks", {})),
+        "nodes": len(kb.get("nodes", {})),
         "files": {
             "chunks": {
                 "path": str(CHUNKS_PKL),
@@ -377,11 +414,13 @@ def kb_status() -> dict:
 def reload_kb() -> dict:
     """
     Force reload of KB artifacts from disk.
-    Useful after regenerating PKL files.
+    Useful after regenerating PKL files outside of watch mode.
     """
+    global _kb
     before = _kb_mtimes()
-    load_kb.cache_clear()
-    kb = load_kb()
+    with _kb_lock:
+        _kb = _load_kb_from_disk()
+        kb = _kb
     after = _kb_mtimes()
 
     return {
@@ -394,6 +433,139 @@ def reload_kb() -> dict:
         "mtimes_after": after,
     }
 
+
+# ── in-process watch (--watch-dir) ──────────────────────────────────────────
+
+def _watch_process_file(file_path: str) -> list:
+    """Route a changed file to the correct make_source processor."""
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).parent.parent))
+    import make_source as _ms  # noqa: PLC0415
+
+    if file_path.endswith('.md'):
+        return _ms.process_md_file(file_path)
+    if file_path.endswith(('.yaml', '.yml')):
+        base = os.path.splitext(file_path)[0]
+        if os.path.exists(base + '.go') or _ms._is_go_meta_yaml(file_path):
+            return _ms.process_go_yaml(file_path)
+        if os.path.exists(base + '.py') or _ms._is_py_meta_yaml(file_path):
+            return _ms.process_py_yaml(file_path)
+        if os.path.exists(base + '.md'):
+            return []
+        return _ms.process_yaml_file(file_path)
+    return []
+
+
+def _incremental_update_kb(changed: list, deleted: list) -> dict:
+    """Apply file changes to the in-memory KB. Must be called under _kb_lock."""
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).parent.parent))
+    import make_source as _ms  # noqa: PLC0415
+
+    kb = _kb
+    if kb is None:
+        return {'removed': 0, 'added': 0, 'total': 0}
+
+    # Remove stale chunks (changed files will be re-added below)
+    fp_set = set(changed + deleted)
+    stale_ids = {
+        cid for cid, c in kb['chunks'].items()
+        if fp_set & set(c.get('file_paths', [c.get('file_path', '')]))
+    }
+    for cid in stale_ids:
+        kb['chunks'].pop(cid, None)
+        kb['embeddings_by_id'].pop(cid, None)
+
+    # Reprocess changed files
+    new_chunks: list = []
+    for fp in changed:
+        try:
+            new_chunks.extend(_watch_process_file(fp))
+        except Exception as exc:
+            print(f"[watch] warn {os.path.basename(fp)}: {exc}", flush=True)
+
+    # Assign IDs continuing from current max
+    nums = [int(c[1:]) for c in kb['chunks'] if c.startswith('c') and c[1:].isdigit()]
+    next_id = max(nums, default=0) + 1
+    for i, chunk in enumerate(new_chunks):
+        chunk['id'] = f'c{next_id + i}'
+        chunk.setdefault('file_paths', [chunk.get('file_path', '')])
+
+    # Embed only new chunks — model already loaded
+    model = kb.get('embedding_model')
+    if new_chunks and model:
+        texts = [c.get('text', '') for c in new_chunks]
+        vecs = model.encode(texts, normalize_embeddings=True, batch_size=32, show_progress_bar=False)
+        for chunk, vec in zip(new_chunks, vecs):
+            kb['chunks'][chunk['id']] = chunk
+            kb['embeddings_by_id'][chunk['id']] = vec.astype('float32')
+
+    # Rebuild FAISS from all current embeddings (no re-encoding)
+    emb = kb['embeddings_by_id']
+    if emb:
+        id_order = list(emb.keys())
+        mat = np.stack([emb[cid] for cid in id_order]).astype('float32')
+        new_idx = faiss.IndexFlatIP(mat.shape[1])
+        new_idx.add(mat)
+        kb['faiss_index'] = new_idx
+        kb['faiss_chunk_ids'] = id_order
+
+    # Rebuild BM25 + inverted index from all current chunks (fast — no encoding)
+    all_chunks = list(kb['chunks'].values())
+    if all_chunks:
+        bm25 = _ms.build_bm25_index(all_chunks)
+        kb['inverted'] = _ms.create_bm25_inverted_index(all_chunks, bm25)
+        kb['bm25'] = bm25
+
+    return {'removed': len(stale_ids), 'added': len(new_chunks), 'total': len(kb['chunks'])}
+
+
+def _file_hash(path: str) -> str:
+    try:
+        with open(path, 'rb') as f:
+            return hashlib.sha256(f.read()).hexdigest()
+    except OSError:
+        return ''
+
+
+def _scan_watch_dir(watch_dir: Path) -> dict:
+    result = {}
+    for root, _, files in os.walk(watch_dir):
+        for fname in files:
+            if any(fname.endswith(e) for e in ('.md', '.yaml', '.yml')) and not fname.startswith('.'):
+                p = os.path.join(root, fname)
+                result[p] = _file_hash(p)
+    return result
+
+
+def _watch_loop() -> None:
+    """Background daemon thread: polls watch_dir, applies incremental updates."""
+    state_path = DATA_DIR.parent / '.file_state.json'
+    try:
+        file_state: dict = json.loads(state_path.read_text()) if state_path.exists() else {}
+    except Exception:
+        file_state = {}
+
+    print(f"[watch] watching {_watch_dir}  interval={_watch_interval}s", flush=True)
+    while True:
+        time.sleep(_watch_interval)
+        try:
+            current = _scan_watch_dir(_watch_dir)
+            changed = [p for p, h in current.items() if file_state.get(p) != h]
+            deleted = [p for p in file_state if p not in current]
+            if changed or deleted:
+                ts = time.strftime('%H:%M:%S')
+                print(f"[watch {ts}] {len(changed)} changed, {len(deleted)} deleted", flush=True)
+                with _kb_lock:
+                    s = _incremental_update_kb(changed, deleted)
+                file_state = current
+                state_path.write_text(json.dumps(file_state, indent=2))
+                print(f"[watch] removed={s['removed']} added={s['added']} total={s['total']}", flush=True)
+        except Exception as exc:
+            print(f"[watch] error: {exc}", flush=True)
+
+
+# ── MCP tools ────────────────────────────────────────────────────────────────
 
 @mcp.tool()
 def list_edge_types() -> list[str]:
@@ -1642,11 +1814,26 @@ DEFAULT_PORT = int(os.environ.get("MCP_PORT", "8000"))
 
 
 def main() -> None:
+    global _watch_dir, _watch_interval
+
     parser = argparse.ArgumentParser(description="CIC Graph MCP Server")
     parser.add_argument("--sse", action="store_true", help="Run as SSE server")
     parser.add_argument("--host", default=DEFAULT_HOST, help=f"SSE bind host (default: {DEFAULT_HOST}, env: MCP_HOST)")
     parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"SSE bind port (default: {DEFAULT_PORT}, env: MCP_PORT)")
+    parser.add_argument("--watch-dir", metavar="DIR",
+                        default=os.environ.get("KB_WATCH_DIR"),
+                        help="Watch this directory for file changes and update KB in-memory (env: KB_WATCH_DIR)")
+    parser.add_argument("--watch-interval", type=float, default=float(os.environ.get("KB_WATCH_INTERVAL", "2")),
+                        help="Poll interval for --watch-dir in seconds (default: 2, env: KB_WATCH_INTERVAL)")
     args = parser.parse_args()
+
+    if args.watch_dir:
+        _watch_dir = Path(args.watch_dir).resolve()
+        _watch_interval = args.watch_interval
+        # Pre-load KB before starting watcher so the model is already in memory
+        load_kb()
+        t = threading.Thread(target=_watch_loop, daemon=True, name="kb-watcher")
+        t.start()
 
     if args.sse:
         print(f"Starting SSE server on http://{args.host}:{args.port}")

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -517,7 +517,30 @@ def _incremental_update_kb(changed: list, deleted: list) -> dict:
         kb['inverted'] = _ms.create_bm25_inverted_index(all_chunks, bm25)
         kb['bm25'] = bm25
 
-    return {'removed': len(stale_ids), 'added': len(new_chunks), 'total': len(kb['chunks'])}
+    # Rebuild knowledge graph from all current chunks + embeddings (no re-encoding)
+    emb = kb['embeddings_by_id']
+    if all_chunks and emb:
+        id_order = [c['id'] for c in all_chunks if c['id'] in emb]
+        emb_mat = np.stack([emb[cid] for cid in id_order]).astype('float32')
+        ordered_chunks = [kb['chunks'][cid] for cid in id_order]
+        nodes_list, edges_list = _ms.create_knowledge_graph_with_content(ordered_chunks, emb_mat)
+        kb['nodes'] = {n['id']: n for n in nodes_list}
+        kb['edges'] = edges_list
+        adj: dict = {}
+        for e in edges_list:
+            src = str(e.get('source') or e.get('from') or e.get('src') or '')
+            if src:
+                adj.setdefault(src, []).append(e)
+        kb['adj'] = adj
+        chunk_to_nodes: dict = {}
+        for nid, node in kb['nodes'].items():
+            cid = node.get('chunk_id')
+            if cid:
+                chunk_to_nodes.setdefault(str(cid), []).append(nid)
+        kb['chunk_to_nodes'] = chunk_to_nodes
+
+    return {'removed': len(stale_ids), 'added': len(new_chunks), 'total': len(kb['chunks']),
+            'nodes': len(kb.get('nodes', {})), 'edges': len(kb.get('edges', []))}
 
 
 def _file_hash(path: str) -> str:
@@ -560,6 +583,9 @@ def _bootstrap_kb_from_source(source_dir: Path) -> None:
     inv = _ms.create_bm25_inverted_index(chunks, bm25)
     faiss_idx = _ms.build_faiss_index(embeddings)
 
+    print("[boot] building knowledge graph ...", flush=True)
+    nodes_list, edges_list = _ms.create_knowledge_graph_with_content(chunks, embeddings)
+
     pkl_dir = DATA_DIR
     pkl_dir.mkdir(parents=True, exist_ok=True)
 
@@ -570,6 +596,8 @@ def _bootstrap_kb_from_source(source_dir: Path) -> None:
         ('bm25.pkl', bm25),
         ('chunk_ids.pkl', [c['id'] for c in chunks]),
         ('model_name.pkl', model_name),
+        ('graph_nodes.pkl', {n['id']: n for n in nodes_list}),
+        ('graph_edges.pkl', {e['id']: e for e in edges_list if 'id' in e}),
     ]:
         (pkl_dir / name).write_bytes(_pickle.dumps(obj))
 
@@ -579,7 +607,7 @@ def _bootstrap_kb_from_source(source_dir: Path) -> None:
     current = _scan_watch_dir(source_dir)
     (DATA_DIR.parent / '.file_state.json').write_text(json.dumps(current, indent=2))
 
-    print(f"[boot] done — {len(chunks)} chunks written to {pkl_dir}", flush=True)
+    print(f"[boot] done — {len(chunks)} chunks, {len(nodes_list)} nodes, {len(edges_list)} edges → {pkl_dir}", flush=True)
 
 
 def _watch_loop() -> None:

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -538,6 +538,50 @@ def _scan_watch_dir(watch_dir: Path) -> dict:
     return result
 
 
+def _bootstrap_kb_from_source(source_dir: Path) -> None:
+    """Build PKL artifacts from source_dir when starting fresh (no chunks.pkl)."""
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).parent.parent))
+    import make_source as _ms  # noqa: PLC0415
+
+    print(f"[boot] scanning {source_dir} ...", flush=True)
+    chunks = _ms.process_directory(str(source_dir))
+    chunks = _ms._dedup_chunks(chunks)
+    chunks.sort(key=lambda c: (c.get('file_path', ''), c.get('start_line', 0)))
+    for i, chunk in enumerate(chunks):
+        chunk['id'] = f'c{i + 1}'
+
+    print(f"[boot] {len(chunks)} chunks — embedding ...", flush=True)
+    model_name = _ms.EMBEDDING_MODEL
+    model, embeddings = _ms.create_embeddings([c['text'] for c in chunks], model_name)
+
+    print("[boot] building indexes ...", flush=True)
+    bm25 = _ms.build_bm25_index(chunks)
+    inv = _ms.create_bm25_inverted_index(chunks, bm25)
+    faiss_idx = _ms.build_faiss_index(embeddings)
+
+    pkl_dir = DATA_DIR
+    pkl_dir.mkdir(parents=True, exist_ok=True)
+
+    import pickle as _pickle
+    for name, obj in [
+        ('chunks.pkl', {c['id']: c for c in chunks}),
+        ('inverted_index.pkl', inv),
+        ('bm25.pkl', bm25),
+        ('chunk_ids.pkl', [c['id'] for c in chunks]),
+        ('model_name.pkl', model_name),
+    ]:
+        (pkl_dir / name).write_bytes(_pickle.dumps(obj))
+
+    faiss.write_index(faiss_idx, str(pkl_dir / 'faiss.index'))
+
+    # Persist file state for the watcher
+    current = _scan_watch_dir(source_dir)
+    (DATA_DIR.parent / '.file_state.json').write_text(json.dumps(current, indent=2))
+
+    print(f"[boot] done — {len(chunks)} chunks written to {pkl_dir}", flush=True)
+
+
 def _watch_loop() -> None:
     """Background daemon thread: polls watch_dir, applies incremental updates."""
     state_path = DATA_DIR.parent / '.file_state.json'
@@ -1830,7 +1874,11 @@ def main() -> None:
     if args.watch_dir:
         _watch_dir = Path(args.watch_dir).resolve()
         _watch_interval = args.watch_interval
-        # Pre-load KB before starting watcher so the model is already in memory
+        # Build initial KB from source if chunks.pkl is missing
+        if not CHUNKS_PKL.exists():
+            print(f"[watch] chunks.pkl not found — building initial KB from {_watch_dir} ...", flush=True)
+            _bootstrap_kb_from_source(_watch_dir)
+        # Pre-load KB so the embedding model is in memory before the watcher starts
         load_kb()
         t = threading.Thread(target=_watch_loop, daemon=True, name="kb-watcher")
         t.start()

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Graph MCP server for CIC knowledge base stored in PKL files (legacy format supported).
+CIC-Relay MCP server for Relay-specific knowledge base stored in PKL files (legacy format supported).
 
 Read-only MCP server that exposes:
 - token search via inverted_index.pkl
@@ -26,6 +26,8 @@ import hashlib
 import json
 import threading
 import time
+import subprocess
+import sys
 import numpy as np
 import faiss
 from pathlib import Path
@@ -34,16 +36,17 @@ from typing import Any, Optional
 from mcp.server.fastmcp import FastMCP
 from sentence_transformers import SentenceTransformer
 
-# ── watch-mode globals ───────────────────────────────────────────────────────
+# ── KB state globals ────────────────────────────────────────────────────────
 _kb: dict | None = None
 _kb_lock = threading.RLock()
-_watch_dir: Path | None = None
-_watch_interval: float = 2.0
+_kb_mtime: float = 0  # last known mtime of KB artifacts (for auto-reload detection)
+_kb_ready: bool = False  # True when KB is loaded and ready for queries
 
-mcp = FastMCP("cic-graph")
+# MCP server name — can be overridden via environment or later in main()
+MCP_SERVER_NAME = os.environ.get("MCP_SERVER_NAME", "cic-relay")
+mcp = FastMCP(MCP_SERVER_NAME)
 
-# Adjust paths to point to the correct location relative to this script
-BASE_DIR = Path(__file__).parent.parent
+# KB data paths
 DATA_DIR = Path(os.environ.get("KB_DATA_DIR", str(Path.cwd() / "kb_data" / "pkl")))
 
 CHUNKS_PKL = Path(os.environ.get("CHUNKS_PKL", str(DATA_DIR / "chunks.pkl")))
@@ -63,6 +66,8 @@ MAX_NEIGHBORS = int(os.environ.get("MAX_NEIGHBORS", "200"))
 MAX_RESOLVE_MATCHES = int(os.environ.get("MAX_RESOLVE_MATCHES", "200"))
 MAX_SEARCH_CODE_HITS = int(os.environ.get("MAX_SEARCH_CODE_HITS", "10"))
 ENABLE_SEARCH_CODE = os.environ.get("ENABLE_SEARCH_CODE", "true").lower() == "true"
+ENABLE_MUTATIONS = os.environ.get("ENABLE_MUTATIONS", "false").lower() == "true"
+REBUILD_GRAPH_ON_WATCH = os.environ.get("REBUILD_GRAPH_ON_WATCH", "false").lower() == "true"
 
 # Rule prioritization constants
 RULE_HINTS = [
@@ -104,12 +109,78 @@ def _normalize_line_range(val: Any) -> Optional[list[int]]:
     return None
 
 
-def load_kb() -> dict[str, Any]:
-    """Return the in-memory KB, loading from disk on first call."""
-    global _kb
+def validate_source_path(file_path: str) -> tuple[bool, str]:
+    """Validate that file_path is within SOURCE_DIR and is not absolute.
+
+    Returns: (is_valid, reason)
+    """
+    if Path(file_path).is_absolute():
+        return False, "Absolute paths not allowed — use relative path within SOURCE_DIR"
+
+    # Resolve relative to SOURCE_DIR
+    target = (SOURCE_DIR / file_path).resolve()
+
+    # Check containment
+    try:
+        target.relative_to(SOURCE_DIR)
+    except ValueError:
+        return False, f"Path escapes SOURCE_DIR: {file_path}"
+
+    return True, ""
+
+
+def load_manifest() -> dict:
+    """Load kb_manifest.json if it exists, return empty dict otherwise."""
+    manifest_path = DATA_DIR.parent / "kb_manifest.json"
+    if manifest_path.exists():
+        try:
+            with manifest_path.open() as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+def check_kb_ready() -> tuple[bool, str]:
+    """Check if KB is ready for queries.
+
+    Returns: (is_ready, reason)
+    If not ready, queries should fail with this reason.
+    """
+    if not _kb_ready:
+        return False, "KB is refreshing graph — please retry in a moment"
+    if _kb is None:
+        return False, "KB not loaded — call reload_kb() first"
+    return True, ""
+
+
+def load_kb(auto_reload: bool = True) -> dict[str, Any]:
+    """Return the in-memory KB, loading from disk on first call.
+
+    If auto_reload=True, check if any artifact was modified since last load
+    and reload if needed (for watch-based updates).
+    """
+    global _kb, _kb_mtime
     with _kb_lock:
         if _kb is None:
             _kb = _load_kb_from_disk()
+            _kb_mtime = max(
+                p.stat().st_mtime for p in [CHUNKS_PKL, NODES_PKL, EDGES_PKL]
+                if p.exists()
+            ) if auto_reload else 0
+            return _kb
+
+        # Check if artifacts were modified (watch-based update detected)
+        if auto_reload and CHUNKS_PKL.exists():
+            current_mtime = max(
+                p.stat().st_mtime for p in [CHUNKS_PKL, NODES_PKL, EDGES_PKL]
+                if p.exists()
+            )
+            if current_mtime > _kb_mtime:
+                print(f"[kb] artifact mtime changed — reloading KB", flush=True)
+                _kb = _load_kb_from_disk()
+                _kb_mtime = current_mtime
+
         return _kb
 
 
@@ -366,7 +437,6 @@ def kb_status() -> dict:
     return {
         "data_dir": str(DATA_DIR),
         "kb_loaded": _kb is not None,
-        "watch_dir": str(_watch_dir) if _watch_dir else None,
         "chunks": len(kb.get("chunks", {})),
         "nodes": len(kb.get("nodes", {})),
         "files": {
@@ -406,7 +476,8 @@ def kb_status() -> dict:
                 "mtime": BM25_PKL.stat().st_mtime if BM25_PKL.exists() else None,
                 "size": BM25_PKL.stat().st_size if BM25_PKL.exists() else None,
             },
-        }
+        },
+        "manifest": load_manifest(),
     }
 
 
@@ -431,6 +502,119 @@ def reload_kb() -> dict:
         "tokens": len(kb["inverted"]),
         "mtimes_before": before,
         "mtimes_after": after,
+    }
+
+
+@mcp.tool()
+def refresh_graph() -> dict:
+    """
+    Manually rebuild the knowledge graph from current chunks and embeddings.
+
+    This is a BLOCKING operation that:
+    1. Locks the KB (blocks all queries)
+    2. Sets server to NOT_READY state
+    3. Rebuilds graph_nodes.pkl and graph_edges.pkl
+    4. Unlocks and returns to READY state
+
+    Use after: watch has updated chunks/embeddings but graph is stale.
+    Warning: Queries will fail with "not ready" error during rebuild.
+    Returns: {success, nodes_count, edges_count, duration_ms}
+    """
+    global _kb, _kb_ready
+    import time as _time
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).parent.parent))
+    import make_source as _ms  # noqa: PLC0415
+
+    start = _time.time()
+    _kb_ready = False  # Signal: server not ready
+    print(f"[graph] refresh_graph() starting — reloading KB from disk", flush=True)
+
+    try:
+        with _kb_lock:  # LOCK: block all queries and watch updates
+            # CRITICAL: Always reload from disk to ensure graph is built from current chunks/embeddings
+            _kb = _load_kb_from_disk()
+            kb = _kb
+            if kb is None or not kb.get('chunks'):
+                return {
+                    'success': False,
+                    'reason': 'KB not loaded or empty',
+                    'duration_ms': int((_time.time() - start) * 1000)
+                }
+
+            # Collect current chunks in ID order
+            all_chunks = list(kb['chunks'].values())
+            emb_dict = kb.get('embeddings_by_id', {})
+
+            if not emb_dict:
+                return {
+                    'success': False,
+                    'reason': 'no embeddings found',
+                    'duration_ms': int((_time.time() - start) * 1000)
+                }
+
+            # Rebuild graph
+            id_order = [c['id'] for c in all_chunks if c['id'] in emb_dict]
+            if not id_order:
+                return {
+                    'success': False,
+                    'reason': 'no chunks with embeddings',
+                    'duration_ms': int((_time.time() - start) * 1000)
+                }
+
+            ordered_chunks = [c for c in all_chunks if c['id'] in id_order]
+            emb_mat = np.stack([emb_dict[cid] for cid in id_order]).astype('float32')
+
+            print(f"[graph] rebuilding from {len(ordered_chunks)} chunks...", flush=True)
+            nodes_list, edges_list = _ms.create_knowledge_graph_with_content(ordered_chunks, emb_mat)
+
+            # Update KB in memory
+            kb['nodes'] = {n['id']: n for n in nodes_list}
+            kb['edges'] = {e['id']: e for e in edges_list if 'id' in e}
+
+            # Rebuild metadata_index from updated chunks
+            print(f"[graph] rebuilding metadata index...", flush=True)
+            metadata_index = _ms.build_metadata_index(all_chunks)
+            kb['metadata_index'] = metadata_index
+
+            # Persist to disk (atomic writes using temp + rename)
+            import tempfile
+            for pkl_path, data in [(NODES_PKL, kb['nodes']), (EDGES_PKL, kb['edges']), (METADATA_INDEX_PKL, kb['metadata_index'])]:
+                temp_fd, temp_path = tempfile.mkstemp(dir=pkl_path.parent, prefix='.tmp_', suffix='.pkl')
+                try:
+                    with os.fdopen(temp_fd, 'wb') as f:
+                        pickle.dump(data, f)
+                    os.replace(temp_path, str(pkl_path))
+                except Exception:
+                    os.unlink(temp_path)
+                    raise
+
+            # Update manifest to mark graph as ready
+            manifest = load_manifest()
+            manifest['graph_mtime'] = _time.time()
+            manifest['graph_stale'] = False
+            manifest_path = DATA_DIR.parent / "kb_manifest.json"
+            with open(manifest_path, 'w') as f:
+                json.dump(manifest, f, indent=2)
+
+            print(f"[graph] rebuilt {len(nodes_list)} nodes, {len(edges_list)} edges", flush=True)
+
+    except Exception as e:
+        print(f"[graph] error during refresh: {e}", flush=True)
+        return {
+            'success': False,
+            'error': str(e),
+            'duration_ms': int((_time.time() - start) * 1000)
+        }
+    finally:
+        _kb_ready = True  # Signal: server ready again
+        print(f"[graph] refresh_graph() complete — server READY", flush=True)
+
+    return {
+        'success': True,
+        'nodes': len(nodes_list),
+        'edges': len(edges_list),
+        'duration_ms': int((_time.time() - start) * 1000)
     }
 
 
@@ -571,8 +755,15 @@ def _bootstrap_kb_from_source(source_dir: Path) -> None:
     chunks = _ms.process_directory(str(source_dir))
     chunks = _ms._dedup_chunks(chunks)
     chunks.sort(key=lambda c: (c.get('file_path', ''), c.get('start_line', 0)))
-    for i, chunk in enumerate(chunks):
-        chunk['id'] = f'c{i + 1}'
+
+    # Generate persistent IDs (same as make_source.py and kb_watch.py)
+    for chunk in chunks:
+        chunk['id'] = _ms._generate_chunk_id(
+            chunk['file_path'],
+            chunk['type'],
+            chunk.get('section', ''),
+            chunk.get('text', '')
+        )
 
     print(f"[boot] {len(chunks)} chunks — embedding ...", flush=True)
     model_name = _ms.EMBEDDING_MODEL
@@ -1517,8 +1708,16 @@ def _load_promptmap(path: Path) -> dict:
 
 def _save_promptmap(path: Path, data: dict) -> None:
     import yaml as _yaml
-    with path.open("w") as f:
-        _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+    import tempfile
+    # Atomic write: temp file + rename
+    temp_fd, temp_path = tempfile.mkstemp(dir=path.parent, prefix='.tmp_', suffix='.yaml')
+    try:
+        with os.fdopen(temp_fd, "w") as f:
+            _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+        os.replace(temp_path, str(path))
+    except Exception:
+        os.unlink(temp_path)
+        raise
 
 
 def _promptmap_repo_name(path: Path) -> str:
@@ -1676,6 +1875,9 @@ def claim_task(task_id: str, repo: str = "") -> dict:
 
     Returns: {success, repo, task_id, message}
     """
+    if not ENABLE_MUTATIONS:
+        return {"success": False, "task_id": task_id, "message": "mutations disabled; enable with --enable-mutations or ENABLE_MUTATIONS=true"}
+
     for pm_path in _find_promptmaps():
         repo_name = _promptmap_repo_name(pm_path)
         if repo and repo.lower() not in repo_name.lower():
@@ -1696,6 +1898,9 @@ def complete_task(task_id: str, repo: str = "", result_note: str = "") -> dict:
 
     Returns: {success, repo, task_id, message}
     """
+    if not ENABLE_MUTATIONS:
+        return {"success": False, "task_id": task_id, "message": "mutations disabled; enable with --enable-mutations or ENABLE_MUTATIONS=true"}
+
     extra = {"result": result_note} if result_note else None
     for pm_path in _find_promptmaps():
         repo_name = _promptmap_repo_name(pm_path)
@@ -1717,6 +1922,9 @@ def fail_task(task_id: str, reason: str, repo: str = "") -> dict:
 
     Returns: {success, repo, task_id, message}
     """
+    if not ENABLE_MUTATIONS:
+        return {"success": False, "task_id": task_id, "message": "mutations disabled; enable with --enable-mutations or ENABLE_MUTATIONS=true"}
+
     for pm_path in _find_promptmaps():
         repo_name = _promptmap_repo_name(pm_path)
         if repo and repo.lower() not in repo_name.lower():
@@ -1753,6 +1961,15 @@ def update_companion(
     """
     import yaml as _yaml
 
+    # Check if mutations are enabled
+    if not ENABLE_MUTATIONS:
+        return {"success": False, "path": file_path, "message": "mutations disabled; enable with --enable-mutations or ENABLE_MUTATIONS=true"}
+
+    # Validate path containment
+    is_valid, reason = validate_source_path(file_path)
+    if not is_valid:
+        return {"success": False, "path": file_path, "message": reason}
+
     p = Path(file_path)
     if not p.is_absolute():
         p = SOURCE_DIR / file_path
@@ -1787,8 +2004,17 @@ def update_companion(
         return {"success": False, "path": str(p), "message": "no fields to update provided"}
 
     try:
-        with p.open("w") as f:
-            _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+        import tempfile
+        import os
+        # Atomic write: temp file in same directory + rename
+        temp_fd, temp_path = tempfile.mkstemp(dir=p.parent, prefix='.tmp_', suffix='.yaml')
+        try:
+            with os.fdopen(temp_fd, "w") as f:
+                _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+            os.replace(temp_path, str(p))
+        except Exception:
+            os.unlink(temp_path)
+            raise
     except Exception as e:
         return {"success": False, "path": str(p), "message": f"write error: {e}"}
 
@@ -1823,11 +2049,20 @@ def record_decision(
     import yaml as _yaml
     from datetime import datetime, timezone
 
+    # Check if mutations are enabled
+    if not ENABLE_MUTATIONS:
+        return {"success": False, "node_id": node_id, "message": "mutations disabled; enable with --enable-mutations or ENABLE_MUTATIONS=true"}
+
     kb = load_kb()
 
     # Resolve companion path from node if not given
     p: Optional[Path] = None
     if companion_path:
+        # Validate explicit companion_path for containment
+        is_valid, reason = validate_source_path(companion_path)
+        if not is_valid:
+            return {"success": False, "path": companion_path, "message": reason}
+
         p = Path(companion_path)
         if not p.is_absolute():
             p = SOURCE_DIR / companion_path
@@ -1869,8 +2104,17 @@ def record_decision(
     decisions.append(entry)
 
     try:
-        with p.open("w") as f:
-            _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+        import tempfile
+        import os
+        # Atomic write: temp file in same directory + rename
+        temp_fd, temp_path = tempfile.mkstemp(dir=p.parent, prefix='.tmp_', suffix='.yaml')
+        try:
+            with os.fdopen(temp_fd, "w") as f:
+                _yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+            os.replace(temp_path, str(p))
+        except Exception:
+            os.unlink(temp_path)
+            raise
     except Exception as e:
         return {"success": False, "path": str(p), "message": f"write error: {e}"}
 
@@ -1886,30 +2130,108 @@ DEFAULT_PORT = int(os.environ.get("MCP_PORT", "8000"))
 
 
 def main() -> None:
-    global _watch_dir, _watch_interval
-
     parser = argparse.ArgumentParser(description="CIC Graph MCP Server")
+    parser.add_argument("--mcp-name", default=os.environ.get("MCP_SERVER_NAME", "cic-relay"),
+                        help="MCP server name (default: cic-relay, env: MCP_SERVER_NAME)")
     parser.add_argument("--sse", action="store_true", help="Run as SSE server")
-    parser.add_argument("--host", default=DEFAULT_HOST, help=f"SSE bind host (default: {DEFAULT_HOST}, env: MCP_HOST)")
-    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"SSE bind port (default: {DEFAULT_PORT}, env: MCP_PORT)")
-    parser.add_argument("--watch-dir", metavar="DIR",
-                        default=os.environ.get("KB_WATCH_DIR", str(Path.cwd())),
-                        help="Watch this directory for file changes and update KB in-memory (default: cwd, env: KB_WATCH_DIR)")
-    parser.add_argument("--watch-interval", type=float, default=float(os.environ.get("KB_WATCH_INTERVAL", "2")),
-                        help="Poll interval for --watch-dir in seconds (default: 2, env: KB_WATCH_INTERVAL)")
+    parser.add_argument("--host", default=os.environ.get("MCP_HOST", DEFAULT_HOST),
+                        help=f"SSE bind host (default: {DEFAULT_HOST}, env: MCP_HOST)")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("MCP_PORT", DEFAULT_PORT)),
+                        help=f"SSE bind port (default: {DEFAULT_PORT}, env: MCP_PORT)")
+    parser.add_argument("--source", metavar="DIR",
+                        default=os.environ.get("SOURCE_DIR", str(Path.cwd())),
+                        help="Source directory to watch for file changes (default: cwd, env: SOURCE_DIR)")
+    parser.add_argument("--kb-dir", metavar="DIR",
+                        default=os.environ.get("KB_DATA_DIR", "./kb_data"),
+                        help="KB data directory (default: ./kb_data, env: KB_DATA_DIR)")
+    parser.add_argument("--enable-mutations", action="store_true",
+                        default=os.environ.get("ENABLE_MUTATIONS", "").lower() == "true",
+                        help="Enable write operations (update_companion, record_decision). Disabled by default for safety.")
+    parser.add_argument("--rebuild-graph-on-watch", action="store_true",
+                        default=os.environ.get("REBUILD_GRAPH_ON_WATCH", "").lower() == "true",
+                        help="Automatically rebuild graph after incremental file watch. Disabled by default (manual refresh_graph() recommended).")
     args = parser.parse_args()
 
-    if args.watch_dir:
-        _watch_dir = Path(args.watch_dir).resolve()
-        _watch_interval = args.watch_interval
-        # Build initial KB from source if chunks.pkl is missing
-        if not CHUNKS_PKL.exists():
-            print(f"[watch] chunks.pkl not found — building initial KB from {_watch_dir} ...", flush=True)
-            _bootstrap_kb_from_source(_watch_dir)
-        # Pre-load KB so the embedding model is in memory before the watcher starts
-        load_kb()
-        t = threading.Thread(target=_watch_loop, daemon=True, name="kb-watcher")
-        t.start()
+    # Update global paths based on arguments
+    global SOURCE_DIR, ENABLE_MUTATIONS, REBUILD_GRAPH_ON_WATCH
+    SOURCE_DIR = Path(args.source).resolve()
+    ENABLE_MUTATIONS = args.enable_mutations
+    REBUILD_GRAPH_ON_WATCH = args.rebuild_graph_on_watch
+
+    # Note: FastMCP server name is read from --mcp-name arg (default from MCP_SERVER_NAME env).
+    # It is NOT modified here after initialization, as all tools are already registered on the mcp object.
+
+    # Update global DATA_DIR and dependent paths based on --kb-dir argument
+    global DATA_DIR, CHUNKS_PKL, NODES_PKL, EDGES_PKL, INVERTED_PKL, FAISS_INDEX, BM25_PKL, CHUNK_IDS_PKL, MODEL_NAME_PKL, METADATA_INDEX_PKL
+    DATA_DIR = Path(args.kb_dir).resolve() / "pkl"
+
+    CHUNKS_PKL = DATA_DIR / "chunks.pkl"
+    NODES_PKL = DATA_DIR / "graph_nodes.pkl"
+    EDGES_PKL = DATA_DIR / "graph_edges.pkl"
+    INVERTED_PKL = DATA_DIR / "inverted_index.pkl"
+    FAISS_INDEX = DATA_DIR / "faiss.index"
+    BM25_PKL = DATA_DIR / "bm25.pkl"
+    CHUNK_IDS_PKL = DATA_DIR / "chunk_ids.pkl"
+    MODEL_NAME_PKL = DATA_DIR / "model_name.pkl"
+    METADATA_INDEX_PKL = DATA_DIR / "metadata_index.pkl"
+
+    if args.source:
+        source_dir = Path(args.source).resolve()
+        kb_dir = Path(args.kb_dir).resolve()
+
+        # Check if KB needs bootstrap
+        kb_missing = not CHUNKS_PKL.exists()
+        if kb_missing:
+            print(f"[boot] chunks.pkl not found — starting make_source.py to build KB from {source_dir}", flush=True)
+            # Run make_source.py as subprocess (non-blocking, efficient)
+            make_source_script = Path(__file__).parent.parent / "make_source.py"
+            make_source_proc = subprocess.Popen(
+                [sys.executable, str(make_source_script),
+                 "--source", str(source_dir),
+                 "--output-kb", str(kb_dir),
+                 "--output-formats", "pkl"],  # only PKL for speed (MCP server only needs PKL)
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+                text=True
+            )
+            print(f"[boot] started make_source.py (PID {make_source_proc.pid})", flush=True)
+        else:
+            # Pre-load KB so the embedding model is in memory
+            load_kb()
+
+        # Start kb_watch.py as subprocess (inotify-based, efficient)
+        # Will wait for bootstrap to complete if needed
+        kb_watch_script = Path(__file__).parent / "kb_watch.py"
+        watch_proc = subprocess.Popen(
+            [sys.executable, str(kb_watch_script), "--source", str(source_dir), "--kb-dir", str(kb_dir)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+            text=True
+        )
+        print(f"[watch] started kb_watch.py (PID {watch_proc.pid})", flush=True)
+
+        # Start graph refresh monitor if REBUILD_GRAPH_ON_WATCH is enabled
+        if REBUILD_GRAPH_ON_WATCH:
+            def monitor_and_refresh_graph():
+                """Monitor manifest and trigger graph refresh when stale."""
+                last_refresh = 0
+                while True:
+                    try:
+                        manifest = load_manifest()
+                        if manifest.get("graph_stale") and time.time() - last_refresh > 5:  # min 5s between refreshes
+                            print(f"[monitor] graph_stale detected, triggering refresh_graph()", flush=True)
+                            try:
+                                refresh_graph()
+                                last_refresh = time.time()
+                            except Exception as e:
+                                print(f"[monitor] refresh_graph() error: {e}", flush=True)
+                    except Exception:
+                        pass
+                    time.sleep(2)  # Check every 2 seconds
+
+            monitor_thread = threading.Thread(target=monitor_and_refresh_graph, daemon=True)
+            monitor_thread.start()
+            print(f"[monitor] graph auto-refresh enabled", flush=True)
 
     if args.sse:
         print(f"Starting SSE server on http://{args.host}:{args.port}")

--- a/mcp-server/server.yaml
+++ b/mcp-server/server.yaml
@@ -1,0 +1,417 @@
+---
+module: server
+description: 'Graph MCP server for CIC knowledge base stored in PKL files (legacy
+  format supported). Read-only MCP server that exposes: - token search via inverted_index.pkl
+  - chunk/node lookup - graph traversal (neighbors) - simple filtering (by tag/category/used_in)
+  if metadata exists in node/chunk payloads - focus_pack: context gathering with rule
+  prioritization - explain_node: deep dive into specific nodes - search_nodes: lookup
+  nodes by name/label/tags - kb_status: check KB file status - reload_kb: force-reload
+  the knowledge base Works with stdio (default) and SSE (HTTP) if you wrap it similarly
+  to your docs_mcp.py.'
+tags:
+- core
+- gateway
+- interface
+- loader
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: mcp
+  kind: const
+  description: ''
+  references: []
+- name: BASE_DIR
+  kind: const
+  description: ''
+  references: []
+- name: DATA_DIR
+  kind: const
+  description: ''
+  references: []
+- name: CHUNKS_PKL
+  kind: const
+  description: ''
+  references: []
+- name: NODES_PKL
+  kind: const
+  description: ''
+  references: []
+- name: EDGES_PKL
+  kind: const
+  description: ''
+  references: []
+- name: INVERTED_PKL
+  kind: const
+  description: ''
+  references: []
+- name: FAISS_INDEX
+  kind: const
+  description: ''
+  references: []
+- name: BM25_PKL
+  kind: const
+  description: ''
+  references: []
+- name: CHUNK_IDS_PKL
+  kind: const
+  description: ''
+  references: []
+- name: MODEL_NAME_PKL
+  kind: const
+  description: ''
+  references: []
+- name: METADATA_INDEX_PKL
+  kind: const
+  description: ''
+  references: []
+- name: DEFAULT_TOPK
+  kind: const
+  description: ''
+  references: []
+- name: MAX_TOPK
+  kind: const
+  description: ''
+  references: []
+- name: MAX_NEIGHBORS
+  kind: const
+  description: ''
+  references: []
+- name: MAX_RESOLVE_MATCHES
+  kind: const
+  description: ''
+  references: []
+- name: MAX_SEARCH_CODE_HITS
+  kind: const
+  description: ''
+  references: []
+- name: ENABLE_SEARCH_CODE
+  kind: const
+  description: ''
+  references: []
+- name: RULE_HINTS
+  kind: const
+  description: ''
+  references: []
+- name: RULE_FILE_HINTS
+  kind: const
+  description: ''
+  references: []
+- name: _clamp_topk
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _normalize_line_range
+  kind: function
+  decorators: []
+  description: Normalize line range to [start, end] list of ints or None.
+  references: []
+- name: load_kb
+  kind: function
+  decorators:
+  - lru_cache
+  description: Load all PKL artifacts into memory once.
+  references:
+  - sentence_transformers.SentenceTransformer
+  - faiss.read_index
+- name: _tokenize
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _extract_chunk_text
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _extract_chunk_file_paths
+  kind: function
+  decorators: []
+  description: 'Return all file paths for a chunk (dedup-aware: file_paths list).'
+  references: []
+- name: _extract_chunk_file_path
+  kind: function
+  decorators: []
+  description: Return the canonical (primary) file path for a chunk.
+  references: []
+- name: _extract_chunk_section
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _rule_bonus_for_chunk
+  kind: function
+  decorators: []
+  description: Give a deterministic bonus to rule-like chunks/files.
+  references: []
+- name: _kb_mtimes
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: kb_status
+  kind: function
+  decorators:
+  - mcp.tool
+  description: Return detailed status about loaded KB artifacts.
+  references: []
+- name: reload_kb
+  kind: function
+  decorators:
+  - mcp.tool
+  description: Force reload of KB artifacts from disk. Useful after regenerating PKL
+    files.
+  references: []
+- name: list_edge_types
+  kind: function
+  decorators:
+  - mcp.tool
+  description: List all unique edge types found in the graph.
+  references: []
+- name: list_node_types
+  kind: function
+  decorators:
+  - mcp.tool
+  description: List all unique node types (categories) found in the graph.
+  references: []
+- name: search_token
+  kind: function
+  decorators:
+  - mcp.tool
+  description: Lexical single-token search using BM25. Returns a list of {chunk_id,
+    score}.
+  references: []
+- name: search_query
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Semantic search using FAISS + multilingual embeddings. Returns ranked
+    chunks: {chunk_id, score, file_path, line_range}. Falls back to BM25 inverted
+    index if FAISS is not available.'
+  references: []
+- name: search_code
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Substring search in chunk content (slow, linear scan). Useful for
+    finding exact code snippets or literal strings that token search misses. Returns:
+    {chunk_id, content_preview, file_path, line_range}'
+  references: []
+- name: search_nodes
+  kind: function
+  decorators:
+  - mcp.tool
+  description: Search for nodes by name, label, type, tags, or category. Uses the
+    metadata index for O(1) tag/category lookup, then augments with linear label/type
+    scan for full coverage.
+  references: []
+- name: resolve_path
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Find chunks belonging to a specific file path. Args: file_path: The
+    path string to search for. mode: Matching mode. - "prefix": Matches if chunk path
+    starts with file_path (default). - "contains": Matches if file_path is a substring
+    of chunk path. - "exact": Matches if chunk path equals file_path. limit: Max number
+    of chunks to return (default 200). Returns: list of {chunk_id, line_range, file_path}'
+  references: []
+- name: get_chunk
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Return a chunk by id. Args: chunk_id: The ID of the chunk. max_chars:
+    Maximum characters of content to return (default 8000).'
+  references: []
+- name: get_node
+  kind: function
+  decorators:
+  - mcp.tool
+  description: Return a node by id.
+  references: []
+- name: neighbors
+  kind: function
+  decorators:
+  - mcp.tool
+  description: Return outgoing edges from a node. Optionally filter by edge_type.
+  references: []
+- name: focus_pack
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Build an enriched task context bundle. Compared to standard search:
+    - prioritizes rule-like chunks/files (CONTRACT, DoD, LIMITS) - returns ''key_rules''
+    - returns ''recommended_reading_order'''
+  references: []
+- name: explain_node
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Deep dive into a specific node: returns definition, neighbors, associated
+    chunk content, and related files.'
+  references: []
+- name: find_nodes
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Filter nodes by metadata using the prebuilt metadata index (O(1) lookup).
+    Args: category: Filter by category (exact match). tag:      Filter by tag (exact
+    match). used_in:  Filter by used_in context (exact match). top_k:    Max results.'
+  references: []
+- name: impact_analysis
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Analyse the downstream impact of a node: what depends on it, critical
+    paths, used_in coverage. Performs BFS from node_id through the adjacency graph,
+    collects all reachable downstream nodes, aggregates used_in fields, and identifies
+    critical path nodes (highest fan-out). Args: node_id: The node to start from.
+    max_depth: BFS depth limit (default 3, max 5).'
+  references: []
+- name: guided_path
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Build an ordered learning path for a topic through the knowledge graph.
+    Selects entrypoint nodes matching the topic, then traverses the graph in category
+    priority order (concept → architecture → flow → implementation) to return a structured
+    reading sequence. Args: topic: The topic or concept to learn about. max_steps:
+    Maximum nodes in the path (default 10, max 20).'
+  references: []
+- name: SOURCE_DIR
+  kind: const
+  description: ''
+  references: []
+- name: missing_companions
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'List Go source files that lack a companion YAML or have empty semantic
+    fields. Scans the source directory for .go files and reports: - ''missing'': .go
+    files with no companion .yaml at all - ''incomplete'': companion YAMLs exist but
+    category/used_in/related_nodes are all empty Results are sorted by file size descending
+    (larger = higher priority). Args: source_dir: Override the scan root (default:
+    SOURCE_DIR env or source/). include_empty_semantic: Also report companions with
+    no semantic fields filled. limit: Max entries per category (default 50).'
+  references: []
+- name: _PROMPTMAP_PATHS_ENV
+  kind: const
+  description: ''
+  references: []
+- name: _find_promptmaps
+  kind: function
+  decorators: []
+  description: Return all known PROMPTMAP.yaml paths (env override or source dir scan).
+  references: []
+- name: _load_promptmap
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _save_promptmap
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _promptmap_repo_name
+  kind: function
+  decorators: []
+  description: Derive a short repo name from PROMPTMAP path (parent directory names).
+  references: []
+- name: _iter_tasks
+  kind: function
+  decorators: []
+  description: Yield (sprint_num, task_dict) pairs from a PROMPTMAP data structure.
+  references: []
+- name: list_tasks
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'List tasks from PROMPTMAP.yaml files. Args: repo: Filter by repo name
+    substring (e.g. ''CIC-Relay''). Empty = all repos. sprint: Filter by sprint number.
+    None = all sprints. status: Filter by status (''todo'', ''done'', ''in_progress'',
+    ''failed''). None = all. Returns list of dicts with keys: repo, sprint, task,
+    status, priority, prompt (truncated).'
+  references: []
+- name: get_next_task
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Return the highest-priority todo task from PROMPTMAP files. Args:
+    repo: Filter by repo name substring. sprint: Filter by sprint number. None = any
+    sprint. Returns the full task dict (with prompt, tests, accept) or None if no
+    todo tasks found.'
+  references: []
+- name: _update_task_status
+  kind: function
+  decorators: []
+  description: Mutate a task's status in a PROMPTMAP file. Returns True if found and
+    saved.
+  references: []
+- name: claim_task
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Mark a task as in_progress in the PROMPTMAP. Args: task_id: The task
+    identifier string (e.g. ''upstream-source-http''). repo: Repo name substring to
+    narrow the search (optional). Returns: {success, repo, task_id, message}'
+  references: []
+- name: complete_task
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Mark a task as done in the PROMPTMAP. Args: task_id: The task identifier
+    string. repo: Repo name substring to narrow the search (optional). result_note:
+    Short summary of what was done (stored as ''result'' field). Returns: {success,
+    repo, task_id, message}'
+  references: []
+- name: fail_task
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Mark a task as failed in the PROMPTMAP with a reason. Args: task_id:
+    The task identifier string. reason: Why it failed (stored as ''failure_reason''
+    field). repo: Repo name substring to narrow the search (optional). Returns: {success,
+    repo, task_id, message}'
+  references: []
+- name: update_companion
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Update semantic fields in a companion YAML file (Go meta companion).
+    Only updates fields that are explicitly provided (non-empty/non-None). Auto-generated
+    fields (package, objects, references) are never touched. After updating, the file
+    must be committed (Vault Transit hook signs it automatically). Args: file_path:
+    Absolute path or path relative to SOURCE_DIR to the companion .yaml. description:
+    Package-level description (replaces empty description only if provided). category:
+    List of category tags (replaces existing list if provided). used_in: List of usage
+    contexts (replaces existing list if provided). related_nodes: List of related
+    node IDs (replaces existing list if provided). tags: List of keyword tags (replaces
+    existing list if provided). Returns: {success, path, updated_fields, message}'
+  references: []
+- name: record_decision
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Record an agent decision as a note in a companion YAML or standalone
+    decision file. Appends a decision entry to the companion YAML''s ''agent_decisions''
+    list. If no companion_path given, tries to find the companion by node_id lookup.
+    Args: node_id: KB node ID this decision relates to. decision: Short statement
+    of the decision made. rationale: Why this decision was made (optional). companion_path:
+    Explicit path to companion YAML. If empty, resolved from node_id. Returns: {success,
+    path, message}'
+  references: []
+- name: DEFAULT_HOST
+  kind: const
+  description: ''
+  references: []
+- name: DEFAULT_PORT
+  kind: const
+  description: ''
+  references: []
+- name: main
+  kind: function
+  decorators: []
+  description: ''
+  references: []

--- a/mcp-server/server.yaml
+++ b/mcp-server/server.yaml
@@ -1,13 +1,13 @@
 ---
 module: server
-description: 'Graph MCP server for CIC knowledge base stored in PKL files (legacy
-  format supported). Read-only MCP server that exposes: - token search via inverted_index.pkl
-  - chunk/node lookup - graph traversal (neighbors) - simple filtering (by tag/category/used_in)
-  if metadata exists in node/chunk payloads - focus_pack: context gathering with rule
-  prioritization - explain_node: deep dive into specific nodes - search_nodes: lookup
-  nodes by name/label/tags - kb_status: check KB file status - reload_kb: force-reload
-  the knowledge base Works with stdio (default) and SSE (HTTP) if you wrap it similarly
-  to your docs_mcp.py.'
+description: 'CIC-Relay MCP server for Relay-specific knowledge base stored in PKL
+  files (legacy format supported). Read-only MCP server that exposes: - token search
+  via inverted_index.pkl - chunk/node lookup - graph traversal (neighbors) - simple
+  filtering (by tag/category/used_in) if metadata exists in node/chunk payloads -
+  focus_pack: context gathering with rule prioritization - explain_node: deep dive
+  into specific nodes - search_nodes: lookup nodes by name/label/tags - kb_status:
+  check KB file status - reload_kb: force-reload the knowledge base Works with stdio
+  (default) and SSE (HTTP) if you wrap it similarly to your docs_mcp.py.'
 tags:
 - core
 - gateway
@@ -18,11 +18,15 @@ used_in: []
 entrypoint: true
 related_nodes: []
 objects:
-- name: mcp
+- name: _kb_lock
   kind: const
   description: ''
   references: []
-- name: BASE_DIR
+- name: MCP_SERVER_NAME
+  kind: const
+  description: ''
+  references: []
+- name: mcp
   kind: const
   description: ''
   references: []
@@ -90,6 +94,14 @@ objects:
   kind: const
   description: ''
   references: []
+- name: ENABLE_MUTATIONS
+  kind: const
+  description: ''
+  references: []
+- name: REBUILD_GRAPH_ON_WATCH
+  kind: const
+  description: ''
+  references: []
 - name: RULE_HINTS
   kind: const
   description: ''
@@ -103,79 +115,306 @@ objects:
   decorators: []
   description: ''
   references: []
+  calls: []
 - name: _normalize_line_range
   kind: function
   decorators: []
   description: Normalize line range to [start, end] list of ints or None.
   references: []
+  calls: []
+- name: validate_source_path
+  kind: function
+  decorators: []
+  description: 'Validate that file_path is within SOURCE_DIR and is not absolute.
+    Returns: (is_valid, reason)'
+  references: []
+  calls:
+  - target.relative_to
+- name: load_manifest
+  kind: function
+  decorators: []
+  description: Load kb_manifest.json if it exists, return empty dict otherwise.
+  references: []
+  calls:
+  - manifest_path.exists
+  - manifest_path.open
+- name: check_kb_ready
+  kind: function
+  decorators: []
+  description: 'Check if KB is ready for queries. Returns: (is_ready, reason) If not
+    ready, queries should fail with this reason.'
+  references: []
+  calls: []
 - name: load_kb
   kind: function
-  decorators:
-  - lru_cache
-  description: Load all PKL artifacts into memory once.
+  decorators: []
+  description: Return the in-memory KB, loading from disk on first call. If auto_reload=True,
+    check if any artifact was modified since last load and reload if needed (for watch-based
+    updates).
+  references: []
+  calls:
+  - CHUNKS_PKL.exists
+  - _load_kb_from_disk
+  - p.exists
+  - p.stat
+- name: _load_kb_from_disk
+  kind: function
+  decorators: []
+  description: Load all PKL artifacts from disk into a fresh dict.
   references:
+  - numpy.ndarray
   - sentence_transformers.SentenceTransformer
   - faiss.read_index
+  calls:
+  - BM25_PKL.exists
+  - BM25_PKL.open
+  - CHUNK_IDS_PKL.exists
+  - CHUNK_IDS_PKL.open
+  - FAISS_INDEX.exists
+  - FileNotFoundError
+  - METADATA_INDEX_PKL.exists
+  - MODEL_NAME_PKL.exists
+  - MODEL_NAME_PKL.open
+  - adj.setdefault
+  - chunk_to_nodes.setdefault
+  - chunks.items
+  - e.get
+  - edges.values
+  - faiss.read_index
+  - faiss_idx.reconstruct
+  - inverted.get
+  - node.get
+  - nodes.items
+  - nodes_by_id.items
+  - p.exists
+  - p.open
+  - sentence_transformers.SentenceTransformer
 - name: _tokenize
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - q.lower
+  - w.isalpha
 - name: _extract_chunk_text
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - chunk.get
 - name: _extract_chunk_file_paths
   kind: function
   decorators: []
   description: 'Return all file paths for a chunk (dedup-aware: file_paths list).'
   references: []
+  calls:
+  - chunk.get
+  - meta.get
 - name: _extract_chunk_file_path
   kind: function
   decorators: []
   description: Return the canonical (primary) file path for a chunk.
   references: []
+  calls:
+  - _extract_chunk_file_paths
 - name: _extract_chunk_section
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - chunk.get
+  - meta.get
 - name: _rule_bonus_for_chunk
   kind: function
   decorators: []
   description: Give a deterministic bonus to rule-like chunks/files.
   references: []
+  calls:
+  - _extract_chunk_file_path
+  - _extract_chunk_section
+  - _extract_chunk_text
 - name: _kb_mtimes
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - CHUNKS_PKL.exists
+  - CHUNKS_PKL.stat
+  - EDGES_PKL.exists
+  - EDGES_PKL.stat
+  - INVERTED_PKL.exists
+  - INVERTED_PKL.stat
+  - NODES_PKL.exists
+  - NODES_PKL.stat
 - name: kb_status
   kind: function
   decorators:
   - mcp.tool
   description: Return detailed status about loaded KB artifacts.
   references: []
+  calls:
+  - BM25_PKL.exists
+  - BM25_PKL.stat
+  - CHUNKS_PKL.exists
+  - CHUNKS_PKL.stat
+  - EDGES_PKL.exists
+  - EDGES_PKL.stat
+  - FAISS_INDEX.exists
+  - FAISS_INDEX.stat
+  - INVERTED_PKL.exists
+  - INVERTED_PKL.stat
+  - NODES_PKL.exists
+  - NODES_PKL.stat
+  - kb.get
+  - mcp.tool
 - name: reload_kb
   kind: function
   decorators:
   - mcp.tool
   description: Force reload of KB artifacts from disk. Useful after regenerating PKL
-    files.
+    files outside of watch mode.
   references: []
+  calls:
+  - _kb_mtimes
+  - _load_kb_from_disk
+  - mcp.tool
+- name: refresh_graph
+  kind: function
+  decorators:
+  - mcp.tool
+  description: 'Manually rebuild the knowledge graph from current chunks and embeddings.
+    This is a BLOCKING operation that: 1. Locks the KB (blocks all queries) 2. Sets
+    server to NOT_READY state 3. Rebuilds graph_nodes.pkl and graph_edges.pkl 4. Unlocks
+    and returns to READY state Use after: watch has updated chunks/embeddings but
+    graph is stale. Warning: Queries will fail with "not ready" error during rebuild.
+    Returns: {success, nodes_count, edges_count, duration_ms}'
+  references:
+  - numpy.stack
+  calls:
+  - _load_kb_from_disk
+  - _ms.build_metadata_index
+  - _ms.create_knowledge_graph_with_content
+  - _time.time
+  - kb.get
+  - mcp.tool
+  - numpy.stack
+  - tempfile.mkstemp
+- name: _watch_process_file
+  kind: function
+  decorators: []
+  description: Route a changed file to the correct make_source processor.
+  references: []
+  calls:
+  - _ms._is_go_meta_yaml
+  - _ms._is_py_meta_yaml
+  - _ms.process_go_yaml
+  - _ms.process_md_file
+  - _ms.process_py_yaml
+  - _ms.process_yaml_file
+  - file_path.endswith
+- name: _incremental_update_kb
+  kind: function
+  decorators: []
+  description: Apply file changes to the in-memory KB. Must be called under _kb_lock.
+  references:
+  - numpy.stack
+  - faiss.IndexFlatIP
+  calls:
+  - _ms.build_bm25_index
+  - _ms.create_bm25_inverted_index
+  - _ms.create_knowledge_graph_with_content
+  - _watch_process_file
+  - adj.setdefault
+  - c.get
+  - c.startswith
+  - chunk.get
+  - chunk.setdefault
+  - chunk_to_nodes.setdefault
+  - e.get
+  - emb.keys
+  - faiss.IndexFlatIP
+  - kb.get
+  - model.encode
+  - new_chunks.extend
+  - new_idx.add
+  - node.get
+  - numpy.stack
+  - vec.astype
+- name: _file_hash
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - f.read
+- name: _scan_watch_dir
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - _file_hash
+  - fname.endswith
+  - fname.startswith
+- name: _bootstrap_kb_from_source
+  kind: function
+  decorators: []
+  description: Build PKL artifacts from source_dir when starting fresh (no chunks.pkl).
+  references:
+  - faiss.write_index
+  calls:
+  - _ms._dedup_chunks
+  - _ms._generate_chunk_id
+  - _ms.build_bm25_index
+  - _ms.build_faiss_index
+  - _ms.create_bm25_inverted_index
+  - _ms.create_embeddings
+  - _ms.create_knowledge_graph_with_content
+  - _ms.process_directory
+  - _pickle.dumps
+  - _scan_watch_dir
+  - c.get
+  - chunk.get
+  - chunks.sort
+  - faiss.write_index
+  - pkl_dir.mkdir
+- name: _watch_loop
+  kind: function
+  decorators: []
+  description: 'Background daemon thread: polls watch_dir, applies incremental updates.'
+  references: []
+  calls:
+  - _incremental_update_kb
+  - _scan_watch_dir
+  - current.items
+  - file_state.get
+  - state_path.exists
+  - state_path.read_text
+  - state_path.write_text
 - name: list_edge_types
   kind: function
   decorators:
   - mcp.tool
   description: List all unique edge types found in the graph.
   references: []
+  calls:
+  - e.get
+  - mcp.tool
+  - types.add
 - name: list_node_types
   kind: function
   decorators:
   - mcp.tool
   description: List all unique node types (categories) found in the graph.
   references: []
+  calls:
+  - mcp.tool
+  - n.get
+  - types.add
 - name: search_token
   kind: function
   decorators:
@@ -183,6 +422,14 @@ objects:
   description: Lexical single-token search using BM25. Returns a list of {chunk_id,
     score}.
   references: []
+  calls:
+  - _clamp_topk
+  - bm25.get_scores
+  - indexed.sort
+  - kb.get
+  - mcp.tool
+  - token.strip
+  - x.get
 - name: search_query
   kind: function
   decorators:
@@ -191,6 +438,23 @@ objects:
     chunks: {chunk_id, score, file_path, line_range}. Falls back to BM25 inverted
     index if FAISS is not available.'
   references: []
+  calls:
+  - _clamp_topk
+  - _extract_chunk_file_paths
+  - _normalize_line_range
+  - _tokenize
+  - chunk.get
+  - faiss_idx.search
+  - h.get
+  - kb.get
+  - matched.get
+  - matched.setdefault
+  - mcp.tool
+  - meta.get
+  - model.encode
+  - results.append
+  - scores.get
+  - scores.items
 - name: search_code
   kind: function
   decorators:
@@ -199,6 +463,16 @@ objects:
     finding exact code snippets or literal strings that token search misses. Returns:
     {chunk_id, content_preview, file_path, line_range}'
   references: []
+  calls:
+  - _clamp_topk
+  - _extract_chunk_file_paths
+  - _normalize_line_range
+  - chunk.get
+  - code_snippet.strip
+  - content.find
+  - mcp.tool
+  - meta.get
+  - results.append
 - name: search_nodes
   kind: function
   decorators:
@@ -207,6 +481,24 @@ objects:
     metadata index for O(1) tag/category lookup, then augments with linear label/type
     scan for full coverage.
   references: []
+  calls:
+  - _clamp_topk
+  - boosted_chunks.get
+  - boosted_chunks.items
+  - boosted_nodes.get
+  - cat.lower
+  - chunk_to_nodes.get
+  - kb.get
+  - label.lower
+  - mcp.tool
+  - meta_idx.get
+  - node.get
+  - query.lower
+  - results.append
+  - results.sort
+  - scores.get
+  - scores.items
+  - tag.lower
 - name: resolve_path
   kind: function
   decorators:
@@ -217,6 +509,18 @@ objects:
     of chunk path. - "exact": Matches if chunk path equals file_path. limit: Max number
     of chunks to return (default 200). Returns: list of {chunk_id, line_range, file_path}'
   references: []
+  calls:
+  - _extract_chunk_file_paths
+  - _normalize_line_range
+  - chunk.get
+  - file_path.strip
+  - matched_paths.append
+  - mcp.tool
+  - meta.get
+  - mode.lower
+  - path_raw.lower
+  - path_str.startswith
+  - results.append
 - name: get_chunk
   kind: function
   decorators:
@@ -224,18 +528,28 @@ objects:
   description: 'Return a chunk by id. Args: chunk_id: The ID of the chunk. max_chars:
     Maximum characters of content to return (default 8000).'
   references: []
+  calls:
+  - chunk.copy
+  - mcp.tool
+  - out.get
 - name: get_node
   kind: function
   decorators:
   - mcp.tool
   description: Return a node by id.
   references: []
+  calls:
+  - mcp.tool
 - name: neighbors
   kind: function
   decorators:
   - mcp.tool
   description: Return outgoing edges from a node. Optionally filter by edge_type.
   references: []
+  calls:
+  - e.get
+  - edge_type.lower
+  - mcp.tool
 - name: focus_pack
   kind: function
   decorators:
@@ -244,6 +558,26 @@ objects:
     - prioritizes rule-like chunks/files (CONTRACT, DoD, LIMITS) - returns ''key_rules''
     - returns ''recommended_reading_order'''
   references: []
+  calls:
+  - _extract_chunk_file_path
+  - _extract_chunk_section
+  - _rule_bonus_for_chunk
+  - base_score_map.get
+  - e.get
+  - files.add
+  - h.get
+  - key_rules.append
+  - mcp.tool
+  - new_frontier.append
+  - node.get
+  - primary_nodes_set.update
+  - recommended_files.append
+  - related_chunks.add
+  - related_nodes.add
+  - rule.get
+  - scored_chunks_data.append
+  - scored_chunks_data.sort
+  - seen_files.add
 - name: explain_node
   kind: function
   decorators:
@@ -251,6 +585,12 @@ objects:
   description: 'Deep dive into a specific node: returns definition, neighbors, associated
     chunk content, and related files.'
   references: []
+  calls:
+  - _extract_chunk_file_path
+  - _extract_chunk_text
+  - _rule_bonus_for_chunk
+  - mcp.tool
+  - node.get
 - name: find_nodes
   kind: function
   decorators:
@@ -259,6 +599,17 @@ objects:
     Args: category: Filter by category (exact match). tag:      Filter by tag (exact
     match). used_in:  Filter by used_in context (exact match). top_k:    Max results.'
   references: []
+  calls:
+  - _clamp_topk
+  - candidate_sets.append
+  - category.lower
+  - chunk_to_nodes.get
+  - kb.get
+  - mcp.tool
+  - meta_idx.get
+  - out.append
+  - tag.lower
+  - used_in.lower
 - name: impact_analysis
   kind: function
   decorators:
@@ -269,6 +620,20 @@ objects:
     critical path nodes (highest fan-out). Args: node_id: The node to start from.
     max_depth: BFS depth limit (default 3, max 5).'
   references: []
+  calls:
+  - adj.get
+  - downstream.append
+  - edge.get
+  - fan_out.items
+  - mcp.tool
+  - node.get
+  - nodes.get
+  - queue.append
+  - queue.pop
+  - used_in_agg.items
+  - used_in_agg.setdefault
+  - visited.items
+  - visited.values
 - name: guided_path
   kind: function
   decorators:
@@ -279,7 +644,28 @@ objects:
     reading sequence. Args: topic: The topic or concept to learn about. max_steps:
     Maximum nodes in the path (default 10, max 20).'
   references: []
+  calls:
+  - _cat_rank
+  - adj.get
+  - candidate_node_ids.append
+  - children.append
+  - children.sort
+  - chunk_to_nodes.get
+  - edge.get
+  - h.get
+  - kb.get
+  - mcp.tool
+  - node.get
+  - nodes.get
+  - path.append
+  - queue.pop
+  - seen_chunks.add
+  - visited.add
 - name: SOURCE_DIR
+  kind: const
+  description: ''
+  references: []
+- name: _COMPANION_LANGS
   kind: const
   description: ''
   references: []
@@ -287,14 +673,32 @@ objects:
   kind: function
   decorators:
   - mcp.tool
-  description: 'List Go source files that lack a companion YAML or have empty semantic
-    fields. Scans the source directory for .go files and reports: - ''missing'': .go
-    files with no companion .yaml at all - ''incomplete'': companion YAMLs exist but
-    category/used_in/related_nodes are all empty Results are sorted by file size descending
-    (larger = higher priority). Args: source_dir: Override the scan root (default:
-    SOURCE_DIR env or source/). include_empty_semantic: Also report companions with
-    no semantic fields filled. limit: Max entries per category (default 50).'
+  description: 'List Go/Python source files that lack a companion YAML or have empty
+    semantic fields. Scans the source directory for .go and .py files (per `langs`)
+    and reports: - ''missing'': source files with no companion .yaml at all - ''incomplete'':
+    companion YAMLs exist but category/used_in/related_nodes are all empty Results
+    are sorted by file size descending (larger = higher priority). Args: source_dir:
+    Override the scan root (default: SOURCE_DIR env or source/). langs: Which source
+    languages to scan. Default: ["go", "py"]. include_empty_semantic: Also report
+    companions with no semantic fields filled. limit: Max entries per category (default
+    50).'
   references: []
+  calls:
+  - _yaml.safe_load
+  - companion.exists
+  - companion.open
+  - companion.relative_to
+  - data.get
+  - incomplete.append
+  - incomplete.sort
+  - mcp.tool
+  - missing.append
+  - missing.sort
+  - scan_root.exists
+  - scan_root.rglob
+  - src_file.relative_to
+  - src_file.stat
+  - src_file.with_suffix
 - name: _PROMPTMAP_PATHS_ENV
   kind: const
   description: ''
@@ -304,26 +708,40 @@ objects:
   decorators: []
   description: Return all known PROMPTMAP.yaml paths (env override or source dir scan).
   references: []
+  calls:
+  - SOURCE_DIR.rglob
+  - _PROMPTMAP_PATHS_ENV.split
+  - p.strip
 - name: _load_promptmap
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _yaml.safe_load
+  - path.open
 - name: _save_promptmap
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _yaml.dump
+  - tempfile.mkstemp
 - name: _promptmap_repo_name
   kind: function
   decorators: []
   description: Derive a short repo name from PROMPTMAP path (parent directory names).
   references: []
+  calls: []
 - name: _iter_tasks
   kind: function
   decorators: []
   description: Yield (sprint_num, task_dict) pairs from a PROMPTMAP data structure.
   references: []
+  calls:
+  - block.get
+  - data.get
 - name: list_tasks
   kind: function
   decorators:
@@ -334,6 +752,18 @@ objects:
     ''failed''). None = all. Returns list of dicts with keys: repo, sprint, task,
     status, priority, prompt (truncated).'
   references: []
+  calls:
+  - _find_promptmaps
+  - _iter_tasks
+  - _load_promptmap
+  - _promptmap_repo_name
+  - mcp.tool
+  - repo.lower
+  - repo_name.lower
+  - results.append
+  - results.sort
+  - task.get
+  - x.get
 - name: get_next_task
   kind: function
   decorators:
@@ -343,12 +773,28 @@ objects:
     sprint. Returns the full task dict (with prompt, tests, accept) or None if no
     todo tasks found.'
   references: []
+  calls:
+  - _find_promptmaps
+  - _iter_tasks
+  - _load_promptmap
+  - _promptmap_repo_name
+  - mcp.tool
+  - task.get
+  - task.items
 - name: _update_task_status
   kind: function
   decorators: []
   description: Mutate a task's status in a PROMPTMAP file. Returns True if found and
     saved.
   references: []
+  calls:
+  - _load_promptmap
+  - _patch
+  - _save_promptmap
+  - block.get
+  - data.get
+  - task.get
+  - task.update
 - name: claim_task
   kind: function
   decorators:
@@ -357,6 +803,13 @@ objects:
     identifier string (e.g. ''upstream-source-http''). repo: Repo name substring to
     narrow the search (optional). Returns: {success, repo, task_id, message}'
   references: []
+  calls:
+  - _find_promptmaps
+  - _promptmap_repo_name
+  - _update_task_status
+  - mcp.tool
+  - repo.lower
+  - repo_name.lower
 - name: complete_task
   kind: function
   decorators:
@@ -366,6 +819,13 @@ objects:
     Short summary of what was done (stored as ''result'' field). Returns: {success,
     repo, task_id, message}'
   references: []
+  calls:
+  - _find_promptmaps
+  - _promptmap_repo_name
+  - _update_task_status
+  - mcp.tool
+  - repo.lower
+  - repo_name.lower
 - name: fail_task
   kind: function
   decorators:
@@ -375,6 +835,13 @@ objects:
     field). repo: Repo name substring to narrow the search (optional). Returns: {success,
     repo, task_id, message}'
   references: []
+  calls:
+  - _find_promptmaps
+  - _promptmap_repo_name
+  - _update_task_status
+  - mcp.tool
+  - repo.lower
+  - repo_name.lower
 - name: update_companion
   kind: function
   decorators:
@@ -390,6 +857,15 @@ objects:
     node IDs (replaces existing list if provided). tags: List of keyword tags (replaces
     existing list if provided). Returns: {success, path, updated_fields, message}'
   references: []
+  calls:
+  - _yaml.dump
+  - _yaml.safe_load
+  - mcp.tool
+  - p.exists
+  - p.is_absolute
+  - p.open
+  - tempfile.mkstemp
+  - updated.append
 - name: record_decision
   kind: function
   decorators:
@@ -402,6 +878,21 @@ objects:
     Explicit path to companion YAML. If empty, resolved from node_id. Returns: {success,
     path, message}'
   references: []
+  calls:
+  - _yaml.dump
+  - _yaml.safe_load
+  - candidate.exists
+  - candidate2.exists
+  - candidate2.with_suffix
+  - data.setdefault
+  - datetime.now
+  - decisions.append
+  - mcp.tool
+  - node.get
+  - p.exists
+  - p.is_absolute
+  - p.open
+  - tempfile.mkstemp
 - name: DEFAULT_HOST
   kind: const
   description: ''
@@ -415,3 +906,10 @@ objects:
   decorators: []
   description: ''
   references: []
+  calls:
+  - CHUNKS_PKL.exists
+  - manifest.get
+  - mcp.run
+  - monitor_thread.start
+  - parser.add_argument
+  - parser.parse_args

--- a/mk/infra.mk
+++ b/mk/infra.mk
@@ -1,7 +1,11 @@
 # Makefile for Core Infrastructure Tasks
 
+PYTHON := ./p_venv/bin/python
+MCP_HOST ?= 127.0.0.1
+MCP_PORT ?= 8000
+
 # ---- Phony ----
-.PHONY: infra.up infra.down infra.shell infra.build infra.fmt infra.lint infra.typecheck infra.check infra.repo.init infra.deps infra.coverage infra.clean infra.help
+.PHONY: infra.up infra.down infra.shell infra.build infra.fmt infra.lint infra.typecheck infra.check infra.repo.init infra.deps infra.coverage infra.clean infra.help infra.kb.build infra.mcp.run infra.mcp.run.sse infra.mcp.config
 
 # =============================================================================
 # Container Lifecycle Management
@@ -82,6 +86,27 @@ infra.clean:
 	@rm -rf ./htmlcov
 
 # =============================================================================
+# Knowledge Base & MCP Server
+# =============================================================================
+
+infra.mcp.config:
+	@echo "--- Generating .mcp.json for this repo ---"
+	@sed "s|{{REPO_ROOT}}|$(shell pwd)|g" .mcp.json.tpl > .mcp.json
+	@echo ".mcp.json generated at $(shell pwd)"
+
+infra.kb.build:
+	@echo "--- Building knowledge base from ./source ---"
+	@$(PYTHON) make_source.py
+
+infra.mcp.run:
+	@echo "--- Starting MCP server (stdio) ---"
+	@$(PYTHON) mcp-server/server.py
+
+infra.mcp.run.sse:
+	@echo "--- Starting MCP server (SSE / HTTP) on $(MCP_HOST):$(MCP_PORT) ---"
+	@$(PYTHON) mcp-server/server.py --sse --host $(MCP_HOST) --port $(MCP_PORT)
+
+# =============================================================================
 # Infrastructure Help (Implementation Details)
 # =============================================================================
 
@@ -102,6 +127,14 @@ infra.help:
 	@echo ""
 	@echo "Repository Setup:"
 	@echo "  infra.repo.init     Set up the Git hooks for this repository (pre-commit, commit-msg)."
+	@echo ""
+	@echo "Knowledge Base & MCP Server (uses ./p_venv, no Docker):"
+	@echo "  mcp.config          Generate .mcp.json with absolute paths for this repo."
+	@echo "  kb.build            Build the knowledge base from ./source (make_source.py)."
+	@echo "  mcp.run             Start the MCP server in stdio mode."
+	@echo "  mcp.run.sse         Start the MCP server in SSE/HTTP mode."
+	@echo "    MCP_HOST=x.x.x.x   Bind host (default: 127.0.0.1, env: MCP_HOST)"
+	@echo "    MCP_PORT=XXXX       Bind port (default: 8000, env: MCP_PORT)"
 	@echo ""
 	@echo "Infrastructure & Maintenance:"
 	@echo "  infra.deps          (Re)generate requirements.txt and install dependencies into the cache."

--- a/mk/infra.mk
+++ b/mk/infra.mk
@@ -3,9 +3,10 @@
 PYTHON := ./p_venv/bin/python
 MCP_HOST ?= 127.0.0.1
 MCP_PORT ?= 8000
+PROFILE ?= internal
 
 # ---- Phony ----
-.PHONY: infra.up infra.down infra.shell infra.build infra.fmt infra.lint infra.typecheck infra.check infra.repo.init infra.deps infra.coverage infra.clean infra.help infra.kb.build infra.mcp.run infra.mcp.run.sse infra.mcp.config
+.PHONY: infra.up infra.down infra.shell infra.build infra.fmt infra.lint infra.typecheck infra.check infra.repo.init infra.deps infra.coverage infra.clean infra.help infra.kb.gitmodules infra.kb.gitmodules.check infra.kb.build infra.mcp.run infra.mcp.run.sse infra.mcp.config
 
 # =============================================================================
 # Container Lifecycle Management
@@ -94,6 +95,14 @@ infra.mcp.config:
 	@sed "s|{{REPO_ROOT}}|$(shell pwd)|g" .mcp.json.tpl > .mcp.json
 	@echo ".mcp.json generated at $(shell pwd)"
 
+infra.kb.gitmodules:
+	@echo "--- Generating .gitmodules from knowledge.sources.yaml (profile: $(PROFILE)) ---"
+	@$(PYTHON) tools/generate_gitmodules.py --profile $(PROFILE)
+
+infra.kb.gitmodules.check:
+	@echo "--- Checking .gitmodules against knowledge.sources.yaml (profile: $(PROFILE)) ---"
+	@$(PYTHON) tools/generate_gitmodules.py --profile $(PROFILE) --check
+
 infra.kb.build:
 	@echo "--- Building knowledge base from ./source ---"
 	@$(PYTHON) make_source.py
@@ -130,6 +139,8 @@ infra.help:
 	@echo ""
 	@echo "Knowledge Base & MCP Server (uses ./p_venv, no Docker):"
 	@echo "  mcp.config          Generate .mcp.json with absolute paths for this repo."
+	@echo "  kb.gitmodules       Generate .gitmodules from knowledge.sources.yaml (PROFILE=internal|public)."
+	@echo "  kb.gitmodules.check Check .gitmodules matches knowledge.sources.yaml (CI drift check)."
 	@echo "  kb.build            Build the knowledge base from ./source (make_source.py)."
 	@echo "  mcp.run             Start the MCP server in stdio mode."
 	@echo "  mcp.run.sse         Start the MCP server in SSE/HTTP mode."

--- a/py.meta.schema.yaml
+++ b/py.meta.schema.yaml
@@ -1,0 +1,161 @@
+---
+type: object
+required:
+  - module
+  - description
+  - tags
+  - category
+  - used_in
+  - entrypoint
+  - related_nodes
+  - objects
+properties:
+  module:
+    type: string
+    description: Python module name, derived from the file path (e.g. "tools.releaselib.git_service").
+
+  description:
+    type: string
+    description: Human-readable summary of the file's purpose (Hungarian or English). Extracted from the module docstring.
+
+  tags:
+    type: array
+    description: "Thematic tags for AI context integration. Same vocabulary as go.meta.schema.yaml — allows cross-language graph queries by tag. Allowed values:"
+    items:
+      type: string
+      enum:
+        - relay             # Related to AI relay modules
+        - compliance        # Compliance or validation logic
+        - workflow          # Process or pipeline logic
+        - cictor            # Part of the CICTOR decision system
+        - schema            # Schema processing
+        - parser            # Input parsing
+        - guard             # Access or protection logic
+        - core              # Core system logic
+        - doc               # Documentation or explanatory content
+        - interface         # Interface logic with external systems
+        - gateway           # Entry or gateway-related logic
+        - builder           # Build or generation tasks
+        - test              # Validation, testing or debugging logic
+        - meta              # Meta-structures or internal definitions
+        - orchestrator      # Coordinates control or decision chains
+        - decision          # Decision logic
+        - reflector         # Feedback or reflection module
+        - context           # Contextual management
+        - validator         # Data or schema validation
+        - executor          # Direct logic execution
+        - hook              # Event-triggered callable logic
+        - template          # Template component
+        - fallback          # Fallback or alternative behavior
+        - session           # Session or state-handling
+        - metrics           # Metric collection or monitoring
+        - storage           # Storage or persistence
+        - loader            # Config or module loading
+        - renderer          # Output generation
+        - platform-engineering
+        - ci-cd
+        - ecosystem
+
+  category:
+    type: array
+    description: "Functional role(s) of the file. Allowed values:"
+    items:
+      type: string
+      enum:
+        - modul             # General module
+        - decision          # Decision logic
+        - morális           # Moral or rule-based logic
+        - belépési          # Entry point (user or system)
+        - meta              # Internal meta structures
+        - elemző            # Evaluation or analysis logic
+        - concept           # High-level concept
+        - architecture      # Architectural blueprint
+        - ci-cd             # CI/CD related
+
+  used_in:
+    type: array
+    description: "Workflows or processes where this file is used. Allowed values:"
+    items:
+      type: string
+      enum:
+        - decision_flow         # Decision logic execution
+        - validation            # Validation process
+        - generation            # Build or generation pipeline
+        - onboarding            # System initialization
+        - fallback_process      # Fallback handling
+        - distribution          # Software distribution
+        - publishing            # Release publishing
+        - development-process   # Core development process
+        - architecture-review   # Architecture review
+
+  entrypoint:
+    type: boolean
+    description: Whether this file is a system or workflow entry point (e.g. `if __name__ == "__main__":`, a CLI tool, or an MCP server boot file).
+
+  related_nodes:
+    type: array
+    items:
+      type: string
+    description: >
+      References to related concepts, modules, or other Python files.
+      Use relative paths (e.g. 'tools/releaselib/git_service') or concept names.
+
+  objects:
+    type: array
+    description: All top-level objects defined in this Python file (module-level classes, functions, and constants; methods are nested under their class).
+    items:
+      type: object
+      required:
+        - name
+        - kind
+        - description
+      properties:
+        name:
+          type: string
+          description: Identifier name as declared in the Python source.
+
+        kind:
+          type: string
+          description: Kind of the Python declaration.
+          enum:
+            - class         # class Name: ...
+            - function      # module-level def name(...): ...
+            - method        # def name(self, ...): ... inside a class
+            - const         # module-level NAME = ... assignment
+
+        receiver:
+          type: string
+          description: >
+            Owning class name for methods (kind: method).
+            Example: "VaultService" for def sign(self, ...) inside class VaultService.
+
+        decorators:
+          type: array
+          items:
+            type: string
+          description: >
+            Decorator names applied to this object, in source order.
+            Example: ["mcp.tool"] for @mcp.tool(), ["staticmethod"] for @staticmethod.
+            Auto-generated by py.meta.gen.py.
+
+        description:
+          type: string
+          description: Human-readable summary of what this object does. Extracted from its docstring.
+
+        implements:
+          type: array
+          items:
+            type: string
+          description: >
+            Base class(es) or ABC(s) this class derives from. Use "module.Base" for
+            external bases, plain "Base" for local ones. Only relevant for kind: class.
+
+        references:
+          type: array
+          items:
+            type: string
+          description: >
+            Non-stdlib names/objects referenced by this declaration's body.
+            Includes both third-party (e.g. "yaml.safe_load") and same-module
+            cross-file references. Format: "module.Name". Auto-generated by
+            py.meta.gen.py — review and trim as needed.

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,17 @@ cryptography
 pyopenssl
 jsonref
 
+# MCP Server & Knowledge Base
+mcp
+markdown
+pandas
+beautifulsoup4
+langdetect
+scikit-learn
+nltk
+fastapi
+uvicorn
+
 # Testing
 pytest
 pytest-mock

--- a/requirements.in
+++ b/requirements.in
@@ -13,8 +13,10 @@ markdown
 pandas
 beautifulsoup4
 langdetect
-scikit-learn
-nltk
+sentence-transformers
+faiss-cpu
+rank-bm25
+numpy
 fastapi
 uvicorn
 

--- a/schemas.json
+++ b/schemas.json
@@ -1,0 +1,220 @@
+{
+  "manifest": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Manifest Schema",
+    "description": "Schema for the main manifest file, which describes all generated data artifacts.",
+    "type": "object",
+    "required": ["project_name", "generation_timestamp_utc", "files"],
+    "properties": {
+      "project_name": {
+        "type": "string",
+        "description": "The name of the project."
+      },
+      "generation_timestamp_utc": {
+        "type": "string",
+        "format": "date-time",
+        "description": "The UTC timestamp in ISO 8601 format indicating when the data was generated."
+      },
+      "files": {
+        "type": "object",
+        "description": "An object containing metadata for each generated file or group of sharded files.",
+        "additionalProperties": {
+          "$ref": "#/definitions/file_entry"
+        }
+      }
+    },
+    "definitions": {
+      "file_metadata": {
+        "type": "object",
+        "required": ["path", "format"],
+        "properties": {
+          "path": { "type": "string", "description": "The relative path to the file." },
+          "format": { "type": "string", "enum": ["JSON", "Pickle"], "description": "The data format of the file." }
+        }
+      },
+      "sharded_file_metadata": {
+        "type": "object",
+        "required": ["path", "format", "group"],
+        "properties": {
+          "path": { "type": "string", "description": "The relative path to the file." },
+          "format": { "type": "string", "enum": ["JSON", "Pickle"], "description": "The data format of the shards." },
+          "group": { "type": "string", "description": "The group name of the sharded file." }
+        }
+      },
+      "file_entry": {
+        "oneOf": [
+          { "$ref": "#/definitions/file_metadata" },
+          { "$ref": "#/definitions/sharded_file_metadata" }
+        ]
+      }
+    }
+  },
+  "chunks": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Chunks Schema",
+    "description": "Schema for the chunks data object. It's a dictionary mapping chunk IDs to chunk data.",
+    "type": "object",
+    "patternProperties": {
+      "^c\\d+$": {
+        "type": "object",
+        "required": ["id", "text", "file_path", "section", "line_range", "lang", "type"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^c\\d+$" },
+          "text": { "type": "string" },
+          "file_path": { "type": "string" },
+          "section": { "type": "string" },
+          "line_range": { "type": "array", "items": [{ "type": "integer" }, { "type": "integer" }] },
+          "lang": { "type": "string" },
+          "type": { "type": "string" }
+        }
+      }
+    },
+    "additionalProperties": false
+  },
+  "graph_nodes": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Graph Nodes Schema",
+    "description": "Schema for the graph nodes data object.",
+    "type": "object",
+    "patternProperties": {
+      "^n\\d+$": {
+        "type": "object",
+        "required": ["id", "chunk_id", "type", "label", "aliases", "evidence"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^n\\d+$" },
+          "chunk_id": { "type": "string", "pattern": "^c\\d+$" },
+          "type": { "type": "string" },
+          "label": { "type": "string" },
+          "aliases": { "type": "array", "items": { "type": "string" } },
+          "evidence": { "$ref": "#/definitions/evidence_array" }
+        }
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "evidence_array": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["file", "lines"],
+          "properties": {
+            "file": { "type": "string" },
+            "lines": { "type": "array", "items": [{ "type": "integer" }, { "type": "integer" }] }
+          }
+        }
+      }
+    }
+  },
+  "graph_edges_shard": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Graph Edges Shard Schema",
+    "description": "Schema for a single shard of the graph edges data. Each shard is a dictionary mapping edge IDs to edge data.",
+    "type": "object",
+    "patternProperties": {
+      "^e\\d+$": {
+        "type": "object",
+        "required": ["id", "from", "to", "type", "weight", "evidence"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^e\\d+$" },
+          "from": { "type": "string", "pattern": "^n\\d+$" },
+          "to": { "type": "string", "pattern": "^n\\d+$" },
+          "type": { "type": "string" },
+          "weight": { "type": "number" },
+          "evidence": { "$ref": "#/definitions/evidence_array" }
+        }
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "evidence_array": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["file", "lines"],
+          "properties": {
+            "file": { "type": "string" },
+            "lines": { "type": "array", "items": [{ "type": "integer" }, { "type": "integer" }] }
+          }
+        }
+      }
+    }
+  },
+  "inverted_index": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Inverted Index Schema",
+    "description": "Schema for the inverted index.",
+    "type": "object",
+    "additionalProperties": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["chunk_id", "score"],
+        "properties": {
+          "chunk_id": { "type": "string", "pattern": "^c\\d+$" },
+          "score": { "type": "number" }
+        }
+      }
+    }
+  },
+  "graph_edge_indexes_from": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Graph Edge Indexes From Schema",
+    "description": "Schema for the 'from_to' part of the graph edge indexes.",
+    "type": "object",
+    "required": ["from_to"],
+    "properties": {
+      "from_to": {
+        "type": "object",
+        "patternProperties": {
+          "^n\\d+$": {
+            "type": "object",
+            "required": ["file", "data"],
+            "properties": {
+              "file": { "type": "string" },
+              "data": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["to_node", "edge_id"],
+                  "properties": {
+                    "to_node": { "type": "string", "pattern": "^n\\d+$" },
+                    "edge_id": { "type": "string", "pattern": "^e\\d+$" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "additionalProperties": false
+  },
+  "graph_edge_indexes_to": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Graph Edge Indexes To Schema",
+    "description": "Schema for the 'to_from' part of the graph edge indexes.",
+    "type": "object",
+    "required": ["to_from"],
+    "properties": {
+      "to_from": {
+        "type": "object",
+        "patternProperties": {
+          "^n\\d+$": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["from_node", "edge_id"],
+              "properties": {
+                "from_node": { "type": "string", "pattern": "^n\\d+$" },
+                "edge_id": { "type": "string", "pattern": "^e\\d+$" }
+              }
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/sqlite_data/.gitignore
+++ b/sqlite_data/.gitignore
@@ -1,0 +1,3 @@
+# Generated SQLite database - do not commit
+*.sqlite
+*.sqlite3

--- a/sqlite_data/db_schema.json
+++ b/sqlite_data/db_schema.json
@@ -101,6 +101,45 @@
       "indexes": [
         { "name": "idx_inverted_index_chunk_id", "columns": ["chunk_id"] }
       ]
+    },
+    {
+      "name": "chunk_tags",
+      "description": "Tags from companion YAML metadata, one row per chunk-tag pair.",
+      "columns": [
+        { "name": "chunk_id", "type": "TEXT", "not_null": true },
+        { "name": "tag",      "type": "TEXT", "not_null": true }
+      ],
+      "primary_key": ["chunk_id", "tag"],
+      "indexes": [
+        { "name": "idx_chunk_tags_tag",      "columns": ["tag"] },
+        { "name": "idx_chunk_tags_chunk_id", "columns": ["chunk_id"] }
+      ]
+    },
+    {
+      "name": "chunk_categories",
+      "description": "Categories from companion YAML metadata.",
+      "columns": [
+        { "name": "chunk_id",  "type": "TEXT", "not_null": true },
+        { "name": "category",  "type": "TEXT", "not_null": true }
+      ],
+      "primary_key": ["chunk_id", "category"],
+      "indexes": [
+        { "name": "idx_chunk_categories_category", "columns": ["category"] },
+        { "name": "idx_chunk_categories_chunk_id", "columns": ["chunk_id"] }
+      ]
+    },
+    {
+      "name": "chunk_used_in",
+      "description": "used_in values from companion YAML metadata.",
+      "columns": [
+        { "name": "chunk_id", "type": "TEXT", "not_null": true },
+        { "name": "used_in",  "type": "TEXT", "not_null": true }
+      ],
+      "primary_key": ["chunk_id", "used_in"],
+      "indexes": [
+        { "name": "idx_chunk_used_in_used_in",  "columns": ["used_in"] },
+        { "name": "idx_chunk_used_in_chunk_id", "columns": ["chunk_id"] }
+      ]
     }
   ]
 }

--- a/sqlite_data/db_schema.json
+++ b/sqlite_data/db_schema.json
@@ -1,0 +1,106 @@
+{
+  "database_file": "knowledge_base.sqlite",
+  "tables": [
+    {
+      "name": "files",
+      "description": "Stores unique file paths to normalize data.",
+      "columns": [
+        { "name": "id", "type": "INTEGER", "primary_key": true },
+        { "name": "path", "type": "TEXT", "unique": true, "not_null": true }
+      ]
+    },
+    {
+      "name": "terms",
+      "description": "Stores unique words (terms) for the inverted index.",
+      "columns": [
+        { "name": "id", "type": "INTEGER", "primary_key": true },
+        { "name": "term", "type": "TEXT", "unique": true, "not_null": true }
+      ]
+    },
+    {
+      "name": "chunks",
+      "description": "Stores text fragments extracted from source files.",
+      "columns": [
+        { "name": "id", "type": "TEXT", "primary_key": true, "description": "Unique, deterministic identifier for the chunk." },
+        { "name": "file_id", "type": "INTEGER", "not_null": true, "description": "Foreign key to the 'files' table." },
+        { "name": "text", "type": "TEXT", "not_null": true },
+        { "name": "section", "type": "TEXT" },
+        { "name": "start_line", "type": "INTEGER", "not_null": true },
+        { "name": "end_line", "type": "INTEGER", "not_null": true },
+        { "name": "lang", "type": "TEXT" },
+        { "name": "type", "type": "TEXT" }
+      ],
+      "foreign_keys": [
+        { "column": "file_id", "references": "files(id)" }
+      ],
+      "indexes": [
+        { "name": "idx_chunk_location", "columns": ["file_id", "start_line"] }
+      ]
+    },
+    {
+      "name": "nodes",
+      "description": "Represents nodes in the knowledge graph.",
+      "columns": [
+        { "name": "id", "type": "TEXT", "primary_key": true },
+        { "name": "chunk_id", "type": "TEXT", "not_null": true },
+        { "name": "type", "type": "TEXT" },
+        { "name": "label", "type": "TEXT" }
+      ],
+      "foreign_keys": [
+        { "column": "chunk_id", "references": "chunks(id)" }
+      ],
+      "indexes": [
+        { "name": "idx_node_chunk_id", "columns": ["chunk_id"] }
+      ]
+    },
+    {
+      "name": "edges",
+      "description": "Represents relationships between nodes.",
+      "columns": [
+        { "name": "id", "type": "TEXT", "primary_key": true },
+        { "name": "from_node", "type": "TEXT", "not_null": true },
+        { "name": "to_node", "type": "TEXT", "not_null": true },
+        { "name": "type", "type": "TEXT" },
+        { "name": "weight", "type": "REAL", "default": 1.0 }
+      ],
+      "foreign_keys": [
+        { "column": "from_node", "references": "nodes(id)" },
+        { "column": "to_node", "references": "nodes(id)" }
+      ],
+      "indexes": [
+        { "name": "idx_edge_from_node", "columns": ["from_node"] },
+        { "name": "idx_edge_to_node", "columns": ["to_node"] }
+      ]
+    },
+    {
+      "name": "edge_evidence",
+      "description": "Links an edge to a specific chunk as evidence.",
+      "columns": [
+        { "name": "edge_id", "type": "TEXT", "not_null": true },
+        { "name": "chunk_id", "type": "TEXT", "not_null": true }
+      ],
+      "primary_key": ["edge_id", "chunk_id"],
+      "foreign_keys": [
+        { "column": "edge_id", "references": "edges(id)" },
+        { "column": "chunk_id", "references": "chunks(id)" }
+      ]
+    },
+    {
+      "name": "inverted_index",
+      "description": "Maps terms and chunks with their TF-IDF score.",
+      "columns": [
+        { "name": "term_id", "type": "INTEGER", "not_null": true },
+        { "name": "chunk_id", "type": "TEXT", "not_null": true },
+        { "name": "score", "type": "REAL", "not_null": true }
+      ],
+      "primary_key": ["term_id", "chunk_id"],
+      "foreign_keys": [
+        { "column": "term_id", "references": "terms(id)" },
+        { "column": "chunk_id", "references": "chunks(id)" }
+      ],
+      "indexes": [
+        { "name": "idx_inverted_index_chunk_id", "columns": ["chunk_id"] }
+      ]
+    }
+  ]
+}

--- a/tests/compiler/__init__.yaml
+++ b/tests/compiler/__init__.yaml
@@ -1,0 +1,9 @@
+---
+module: compiler.__init__
+description: ''
+tags: []
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects: []

--- a/tests/infra/__init__.yaml
+++ b/tests/infra/__init__.yaml
@@ -1,0 +1,9 @@
+---
+module: infra.__init__
+description: ''
+tags: []
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects: []

--- a/tests/test_compiler.yaml
+++ b/tests/test_compiler.yaml
@@ -1,0 +1,10 @@
+---
+module: test_compiler
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects: []

--- a/tests/test_tools/__init__.yaml
+++ b/tests/test_tools/__init__.yaml
@@ -1,0 +1,9 @@
+---
+module: test_tools.__init__
+description: ''
+tags: []
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects: []

--- a/tests/test_tools/test_compiler.yaml
+++ b/tests/test_tools/test_compiler.yaml
@@ -1,0 +1,190 @@
+---
+module: test_tools.test_compiler
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: PROJECT_ROOT
+  kind: const
+  description: ''
+  references: []
+- name: mock_env
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Auto-mock environment and services for all tests in this module.
+  references:
+  - pytest.fixture
+  calls:
+  - mocker.patch
+  - pytest.fixture
+- name: TestMainCLI
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_no_arguments
+  kind: method
+  receiver: TestMainCLI
+  decorators: []
+  description: ''
+  references:
+  - tools.compiler.main
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - tools.compiler.main
+- name: test_validate_command_success
+  kind: method
+  receiver: TestMainCLI
+  decorators: []
+  description: ''
+  references:
+  - tools.compiler.main
+  calls:
+  - mock_release_manager_class.assert_called_once
+  - mocker.patch
+  - tools.compiler.main
+- name: test_release_command_requires_version
+  kind: method
+  receiver: TestMainCLI
+  decorators: []
+  description: ''
+  references:
+  - tools.compiler.main
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - tools.compiler.main
+- name: test_release_command_success
+  kind: method
+  receiver: TestMainCLI
+  decorators: []
+  description: Test the 'release' command success case.
+  references:
+  - tools.compiler.main
+  calls:
+  - mock_release_manager_class.assert_called_once
+  - mocker.patch
+  - tools.compiler.main
+- name: test_release_command_with_vault_files
+  kind: method
+  receiver: TestMainCLI
+  decorators: []
+  description: Test 'release' command reads Vault token and CA from files.
+  references:
+  - tools.compiler.main
+  calls:
+  - kwargs.get
+  - mocker.patch
+  - tools.compiler.main
+- name: test_main_handles_manual_intervention
+  kind: method
+  receiver: TestMainCLI
+  decorators: []
+  description: Test that main catches ManualInterventionRequired and exits with 0.
+  references:
+  - tools.compiler.main
+  - pytest.raises
+  - tools.releaselib.exceptions.ManualInterventionRequired
+  calls:
+  - mocker.patch
+  - pytest.raises
+  - tools.compiler.main
+  - tools.releaselib.exceptions.ManualInterventionRequired
+- name: test_main_handles_release_error
+  kind: method
+  receiver: TestMainCLI
+  decorators: []
+  description: ''
+  references:
+  - tools.compiler.main
+  - pytest.raises
+  - tools.releaselib.exceptions.ReleaseError
+  calls:
+  - mocker.patch
+  - pytest.raises
+  - tools.compiler.main
+  - tools.releaselib.exceptions.ReleaseError
+- name: TestConfigLoader
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: mock_env
+  kind: method
+  receiver: TestConfigLoader
+  decorators:
+  - pytest.fixture
+  description: ''
+  references:
+  - pytest.fixture
+  calls:
+  - pytest.fixture
+- name: test_load_project_config_io_error
+  kind: method
+  receiver: TestConfigLoader
+  decorators: []
+  description: ''
+  references:
+  - tools.compiler.load_project_config
+  - pytest.raises
+  calls:
+  - IOError
+  - mocker.patch
+  - pytest.raises
+  - tools.compiler.load_project_config
+- name: test_load_project_config_key_error
+  kind: method
+  receiver: TestConfigLoader
+  decorators: []
+  description: ''
+  references:
+  - tools.compiler.load_project_config
+  - pytest.raises
+  calls:
+  - mocker.patch
+  - pytest.raises
+  - tools.compiler.load_project_config
+- name: TestLogging
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: unpatch_logging
+  kind: method
+  receiver: TestLogging
+  decorators:
+  - pytest.fixture
+  description: ''
+  references:
+  - pytest.fixture
+  calls:
+  - mocker.stopall
+  - pytest.fixture
+- name: test_setup_logging_levels
+  kind: method
+  receiver: TestLogging
+  decorators: []
+  description: ''
+  references:
+  - tools.compiler.setup_logging
+  calls:
+  - tools.compiler.setup_logging
+- name: test_colored_formatter
+  kind: method
+  receiver: TestLogging
+  decorators: []
+  description: ''
+  references:
+  - tools.compiler.ColoredFormatter
+  calls:
+  - formatter.format
+  - tools.compiler.ColoredFormatter

--- a/tests/test_tools/test_finalize_release.yaml
+++ b/tests/test_tools/test_finalize_release.yaml
@@ -1,0 +1,290 @@
+---
+module: test_tools.test_finalize_release
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: mock_args
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Fixture to mock argparse arguments with MagicMocks for paths.
+  references:
+  - pytest.fixture
+  calls:
+  - mocker.patch
+- name: mock_env
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Fixture to mock environment variables.
+  references:
+  - pytest.fixture
+  calls:
+  - mocker.patch
+- name: mock_vault
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Fixture to mock the VaultService.
+  references:
+  - pytest.fixture
+  calls:
+  - mocker.patch
+- name: mock_sys_exit
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Fixture to mock sys.exit to prevent test termination.
+  references:
+  - pytest.fixture
+  calls:
+  - mocker.patch
+- name: TestHelperFunctions
+  kind: class
+  decorators: []
+  description: Tests for helper functions like logging and YAML handling.
+  implements: []
+  references: []
+- name: test_setup_logging
+  kind: method
+  receiver: TestHelperFunctions
+  decorators:
+  - pytest.mark.parametrize
+  description: Tests that logging is configured correctly for different verbosity
+    levels.
+  references:
+  - pytest.mark
+  - tools.finalize_release.setup_logging
+  - tools.finalize_release
+  - tools.finalize_release.logging
+  - pytest.MonkeyPatch
+  calls:
+  - m.setattr
+  - tools.finalize_release.setup_logging
+- name: test_colored_formatter
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: Tests the custom colored formatter.
+  references:
+  - tools.finalize_release.LOG_FORMAT
+  - tools.finalize_release
+  - tools.finalize_release.ColoredFormatter
+  calls:
+  - formatter.format
+  - tools.finalize_release.ColoredFormatter
+- name: test_load_yaml_io_error
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: Tests the exception handling in load_yaml for IOError.
+  references:
+  - tools.finalize_release.load_yaml
+  - tools.finalize_release
+  - pytest.raises
+  calls:
+  - IOError
+  - caplog.set_level
+  - mocker.patch
+  - pytest.raises
+  - tools.finalize_release.load_yaml
+- name: test_load_yaml_yaml_error
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: Tests the exception handling in load_yaml for YAMLError.
+  references:
+  - tools.finalize_release.load_yaml
+  - tools.finalize_release
+  - yaml.YAMLError
+  - pytest.raises
+  calls:
+  - caplog.set_level
+  - mocker.mock_open
+  - mocker.patch
+  - pytest.raises
+  - tools.finalize_release.load_yaml
+- name: test_write_yaml_io_error
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: Tests the exception handling in write_yaml.
+  references:
+  - tools.finalize_release.write_yaml
+  - tools.finalize_release
+  - pytest.raises
+  calls:
+  - IOError
+  - caplog.set_level
+  - mocker.patch
+  - pytest.raises
+  - tools.finalize_release.write_yaml
+- name: TestMainExecution
+  kind: class
+  decorators: []
+  description: Test suite for the main execution logic of the script.
+  implements: []
+  references: []
+- name: setup_main_mocks
+  kind: method
+  receiver: TestMainExecution
+  decorators:
+  - pytest.fixture
+  description: Mock dependencies for the main function execution tests.
+  references:
+  - pytest.fixture
+  calls:
+  - mocker.patch
+  - pytest.fixture
+- name: test_main_success_with_cert_file
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - mock_open.assert_called_once_with
+  - mocker.mock_open
+  - mocker.patch
+  - tools.finalize_release.main
+- name: test_main_success_with_vault_path
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - tools.finalize_release.main
+- name: test_main_dry_run
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - caplog.set_level
+  - capsys.readouterr
+  - mocker.mock_open
+  - mocker.patch
+  - tools.finalize_release.main
+- name: test_error_filepath_not_found
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - mock_sys_exit.assert_called_once_with
+  - tools.finalize_release.main
+- name: test_error_cert_file_not_found
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - mock_sys_exit.assert_called_once_with
+  - tools.finalize_release.main
+- name: test_error_checksum_mismatch
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - mock_sys_exit.assert_called_once_with
+  - mocker.patch
+  - tools.finalize_release.main
+- name: test_error_no_metadata_block
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - mock_sys_exit.assert_called_once_with
+  - mocker.patch
+  - tools.finalize_release.main
+- name: test_error_vault_signing_fails
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  - tools.releaselib.exceptions.VaultServiceError
+  calls:
+  - mock_sys_exit.assert_called_once_with
+  - mocker.mock_open
+  - mocker.patch
+  - tools.finalize_release.main
+  - tools.releaselib.exceptions.VaultServiceError
+- name: test_error_vault_cert_fetch_fails
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  - tools.releaselib.exceptions.VaultServiceError
+  calls:
+  - mock_sys_exit.assert_called_once_with
+  - tools.finalize_release.main
+  - tools.releaselib.exceptions.VaultServiceError
+- name: test_error_invalid_vault_path_format
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - mock_sys_exit.assert_called_once_with
+  - tools.finalize_release.main
+- name: test_error_missing_env_vars
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - mock_sys_exit.assert_called_once_with
+  - mocker.patch
+  - tools.finalize_release.main
+- name: test_unexpected_error_handling
+  kind: method
+  receiver: TestMainExecution
+  decorators: []
+  description: ''
+  references:
+  - tools.finalize_release.main
+  - tools.finalize_release
+  calls:
+  - Exception
+  - mock_sys_exit.assert_called_once_with
+  - mocker.patch
+  - tools.finalize_release.main

--- a/tests/test_tools/test_infra.yaml
+++ b/tests/test_tools/test_infra.yaml
@@ -1,0 +1,249 @@
+---
+module: test_tools.test_infra
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: mock_services
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Provides a dictionary of mocked services and configs.
+  references:
+  - pytest.fixture
+  - tools.releaselib.vault_service.VaultService
+  - tools.releaselib.git_service.GitService
+  calls:
+  - mocker.MagicMock
+  - mocker.patch
+- name: TestHelperFunctions
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_load_yaml_file_not_found
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.load_yaml
+  - tools.releaselib.exceptions.ConfigurationError
+  - pytest.raises
+  calls:
+  - mocker.patch
+  - pytest.raises
+  - tools.infra.load_yaml
+- name: test_load_yaml_invalid_yaml
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.load_yaml
+  - tools.releaselib.exceptions.ConfigurationError
+  - pytest.raises
+  calls:
+  - mocker.mock_open
+  - mocker.patch
+  - pytest.raises
+  - tools.infra.load_yaml
+- name: test_load_yaml_empty_file
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.load_yaml
+  calls:
+  - mocker.mock_open
+  - mocker.patch
+  - tools.infra.load_yaml
+- name: test_write_yaml_io_error
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.write_yaml
+  - tools.releaselib.exceptions.ReleaseError
+  - pytest.raises
+  calls:
+  - IOError
+  - mocker.patch
+  - pytest.raises
+  - tools.infra.write_yaml
+- name: test_write_yaml_cleanup_on_error
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.write_yaml
+  - tools.releaselib.exceptions.ReleaseError
+  - pytest.raises
+  calls:
+  - OSError
+  - mock_path_class.assert_called_with
+  - mocker.patch
+  - pytest.raises
+  - tools.infra.write_yaml
+- name: test_get_reproducible_repo_hash_error
+  kind: method
+  receiver: TestHelperFunctions
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.get_reproducible_repo_hash
+  - tools.releaselib.exceptions.ReleaseError
+  - pytest.raises
+  - tools.releaselib.git_service.GitService
+  calls:
+  - Exception
+  - mocker.MagicMock
+  - pytest.raises
+  - tools.infra.get_reproducible_repo_hash
+- name: TestReleaseManagerPhases
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_developer_preparation_phase_success
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.ReleaseManager
+  calls:
+  - manager.run_release_close
+  - tools.infra.ReleaseManager
+- name: test_finalization_phase_success
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.ReleaseManager
+  calls:
+  - manager.run_release_close
+  - tools.infra.ReleaseManager
+- name: test_dry_run_developer_phase
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.write_yaml.assert_not_called
+  - tools.infra.write_yaml
+  - tools.infra.ReleaseManager
+  calls:
+  - manager.run_release_close
+  - tools.infra.ReleaseManager
+  - tools.infra.write_yaml.assert_not_called
+- name: test_invalid_branch
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.releaselib.exceptions.GitStateError
+  - pytest.raises
+  - tools.infra.ReleaseManager
+  calls:
+  - manager.run_release_close
+  - pytest.raises
+  - tools.infra.ReleaseManager
+- name: test_api_accessibility_check_failure
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.ReleaseManager
+  - requests.exceptions
+  calls:
+  - manager.run_release_close
+  - tools.infra.ReleaseManager
+- name: test_finalization_phase_validation_failure
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.releaselib.exceptions.ReleaseError
+  - pytest.raises
+  - tools.infra.ReleaseManager
+  - jsonschema.ValidationError
+  calls:
+  - jsonschema.ValidationError
+  - manager.run_release_close
+  - pytest.raises
+  - tools.infra.ReleaseManager
+- name: test_finalization_phase_dirty_repo_commit
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.ReleaseManager
+  calls:
+  - manager.run_release_close
+  - tools.infra.ReleaseManager
+- name: test_validate_final_project_yaml_generic_exception
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.releaselib.exceptions.ReleaseError
+  - pytest.raises
+  - tools.infra.ReleaseManager
+  calls:
+  - Exception
+  - manager._validate_final_project_yaml
+  - pytest.raises
+  - tools.infra.ReleaseManager
+- name: test_developer_preparation_phase_cleanup_on_error
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.releaselib.exceptions.ReleaseError
+  - pytest.raises
+  - tools.infra.ReleaseManager
+  calls:
+  - Exception
+  - manager.run_release_close
+  - pytest.raises
+  - tools.infra.ReleaseManager
+- name: test_finalization_phase_no_dirty_repo_commit
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.infra.ReleaseManager
+  calls:
+  - manager.run_release_close
+  - tools.infra.ReleaseManager
+- name: test_run_release_close_vault_service_not_initialized
+  kind: method
+  receiver: TestReleaseManagerPhases
+  decorators: []
+  description: ''
+  references:
+  - tools.releaselib.exceptions.VaultServiceError
+  - pytest.raises
+  - tools.infra.ReleaseManager
+  calls:
+  - manager.run_release_close
+  - pytest.raises
+  - tools.infra.ReleaseManager

--- a/tests/test_tools/test_make_source.py
+++ b/tests/test_tools/test_make_source.py
@@ -1,0 +1,250 @@
+import os
+import sys
+import pickle
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from make_source import (
+    build_bm25_index,
+    build_faiss_index,
+    create_bm25_inverted_index,
+    create_knowledge_graph_with_content,
+    process_md_file,
+    process_yaml_file,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_CHUNKS = [
+    {"id": "c1", "text": "A Relay kezeli a hostokat és a szolgáltatásokat.", "file_path": "docs/relay.md", "section": "Relay", "start_line": 1, "end_line": 5, "lang": "hu", "type": "section"},
+    {"id": "c2", "text": "A Host a futtató környezet, VM vagy fizikai gép.", "file_path": "docs/host.md", "section": "Host", "start_line": 1, "end_line": 5, "lang": "hu", "type": "section"},
+    {"id": "c3", "text": "The Service is a functional unit that produces value.", "file_path": "docs/service.md", "section": "Service", "start_line": 1, "end_line": 5, "lang": "en", "type": "section"},
+    {"id": "c4", "text": "Vault Transit engine signs artifacts with ECDSA SHA256.", "file_path": "docs/vault.md", "section": "Vault", "start_line": 1, "end_line": 5, "lang": "en", "type": "section"},
+    {"id": "c5", "text": "A Relay és a Host kapcsolata gráf-alapú, nem fa struktúra.", "file_path": "docs/relay.md", "section": "Graph", "start_line": 6, "end_line": 10, "lang": "hu", "type": "section"},
+]
+
+
+# ---------------------------------------------------------------------------
+# build_bm25_index
+# ---------------------------------------------------------------------------
+
+class TestBuildBm25Index:
+    def test_returns_bm25_object(self):
+        from rank_bm25 import BM25Okapi
+        bm25 = build_bm25_index(SAMPLE_CHUNKS)
+        assert isinstance(bm25, BM25Okapi)
+
+    def test_scores_relevant_chunk_higher(self):
+        bm25 = build_bm25_index(SAMPLE_CHUNKS)
+        scores = bm25.get_scores(["relay"])
+        # c1 and c5 mention "relay" (lowercased), should score > 0
+        assert scores[0] > 0 or scores[4] > 0
+
+    def test_scores_length_matches_chunks(self):
+        bm25 = build_bm25_index(SAMPLE_CHUNKS)
+        scores = bm25.get_scores(["host"])
+        assert len(scores) == len(SAMPLE_CHUNKS)
+
+    def test_empty_text_does_not_raise(self):
+        from rank_bm25 import BM25Okapi
+        bm25 = build_bm25_index([{"id": "c1", "text": ""}])
+        assert isinstance(bm25, BM25Okapi)
+
+
+# ---------------------------------------------------------------------------
+# build_faiss_index
+# ---------------------------------------------------------------------------
+
+class TestBuildFaissIndex:
+    def test_returns_faiss_index(self):
+        import faiss
+        embeddings = np.random.rand(5, 64).astype("float32")
+        # normalize
+        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+        embeddings /= norms
+        index = build_faiss_index(embeddings)
+        assert isinstance(index, faiss.IndexFlatIP)
+
+    def test_index_contains_all_vectors(self):
+        embeddings = np.random.rand(5, 64).astype("float32")
+        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+        embeddings /= norms
+        index = build_faiss_index(embeddings)
+        assert index.ntotal == 5
+
+    def test_search_returns_top_k(self):
+        dim = 64
+        embeddings = np.random.rand(5, dim).astype("float32")
+        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+        embeddings /= norms
+        index = build_faiss_index(embeddings)
+        query = embeddings[0:1]
+        scores, indices = index.search(query, 3)
+        assert scores.shape == (1, 3)
+        assert indices.shape == (1, 3)
+
+    def test_self_similarity_is_highest(self):
+        dim = 64
+        embeddings = np.random.rand(5, dim).astype("float32")
+        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+        embeddings /= norms
+        index = build_faiss_index(embeddings)
+        # query with the first vector — it should be the top hit
+        query = embeddings[0:1]
+        _, indices = index.search(query, 1)
+        assert indices[0][0] == 0
+
+
+# ---------------------------------------------------------------------------
+# create_bm25_inverted_index
+# ---------------------------------------------------------------------------
+
+class TestCreateBm25InvertedIndex:
+    def test_returns_dict(self):
+        bm25 = build_bm25_index(SAMPLE_CHUNKS)
+        inv = create_bm25_inverted_index(SAMPLE_CHUNKS, bm25)
+        assert isinstance(inv, dict)
+
+    def test_contains_known_token(self):
+        bm25 = build_bm25_index(SAMPLE_CHUNKS)
+        inv = create_bm25_inverted_index(SAMPLE_CHUNKS, bm25)
+        assert "relay" in inv or "host" in inv
+
+    def test_entries_have_chunk_id_and_score(self):
+        bm25 = build_bm25_index(SAMPLE_CHUNKS)
+        inv = create_bm25_inverted_index(SAMPLE_CHUNKS, bm25)
+        for token, entries in inv.items():
+            for entry in entries:
+                assert "chunk_id" in entry
+                assert "score" in entry
+                assert entry["score"] > 0.01
+
+    def test_entries_sorted_by_score_descending(self):
+        bm25 = build_bm25_index(SAMPLE_CHUNKS)
+        inv = create_bm25_inverted_index(SAMPLE_CHUNKS, bm25)
+        for token, entries in inv.items():
+            scores = [e["score"] for e in entries]
+            assert scores == sorted(scores, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# create_knowledge_graph_with_content
+# ---------------------------------------------------------------------------
+
+class TestCreateKnowledgeGraph:
+    def _make_embeddings(self, n=5, dim=64):
+        emb = np.random.rand(n, dim).astype("float32")
+        norms = np.linalg.norm(emb, axis=1, keepdims=True)
+        return emb / norms
+
+    def test_returns_nodes_and_edges(self):
+        embeddings = self._make_embeddings()
+        nodes, edges = create_knowledge_graph_with_content(SAMPLE_CHUNKS, embeddings)
+        assert len(nodes) == len(SAMPLE_CHUNKS)
+        assert len(edges) > 0
+
+    def test_node_ids_sequential(self):
+        embeddings = self._make_embeddings()
+        nodes, _ = create_knowledge_graph_with_content(SAMPLE_CHUNKS, embeddings)
+        ids = [n["id"] for n in nodes]
+        assert ids == [f"n{i+1}" for i in range(len(SAMPLE_CHUNKS))]
+
+    def test_nodes_have_chunk_ids(self):
+        embeddings = self._make_embeddings()
+        nodes, _ = create_knowledge_graph_with_content(SAMPLE_CHUNKS, embeddings)
+        chunk_ids = {n["chunk_id"] for n in nodes}
+        assert chunk_ids == {c["id"] for c in SAMPLE_CHUNKS}
+
+    def test_refers_to_edges_sequential(self):
+        embeddings = self._make_embeddings()
+        _, edges = create_knowledge_graph_with_content(SAMPLE_CHUNKS, embeddings)
+        refers_to = [e for e in edges if e["type"] == "refers-to"]
+        assert len(refers_to) == len(SAMPLE_CHUNKS) - 1
+
+    def test_related_to_edges_high_similarity(self):
+        # Force high cosine similarity between first two vectors
+        dim = 64
+        base = np.random.rand(dim).astype("float32")
+        base /= np.linalg.norm(base)
+        embeddings = np.tile(base, (5, 1))
+        # add tiny noise so they're not identical
+        embeddings += np.random.rand(5, dim).astype("float32") * 0.001
+        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+        embeddings /= norms
+        _, edges = create_knowledge_graph_with_content(SAMPLE_CHUNKS, embeddings)
+        related = [e for e in edges if e["type"] == "related-to"]
+        assert len(related) > 0
+
+    def test_edge_ids_unique(self):
+        embeddings = self._make_embeddings()
+        _, edges = create_knowledge_graph_with_content(SAMPLE_CHUNKS, embeddings)
+        ids = [e["id"] for e in edges]
+        assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# process_md_file / process_yaml_file
+# ---------------------------------------------------------------------------
+
+class TestFileProcessors:
+    def test_process_md_file_returns_chunks(self, tmp_path):
+        md = tmp_path / "test.md"
+        md.write_text("# Section One\nContent here.\n\n## Section Two\nMore content.\n")
+        chunks = process_md_file(str(md))
+        assert len(chunks) >= 2
+        assert all("text" in c and "file_path" in c for c in chunks)
+
+    def test_process_md_file_sets_file_path(self, tmp_path):
+        md = tmp_path / "test.md"
+        md.write_text("# Title\nBody text.\n")
+        chunks = process_md_file(str(md))
+        assert all(c["file_path"] == str(md) for c in chunks)
+
+    def test_process_yaml_file_returns_chunk(self, tmp_path):
+        yml = tmp_path / "test.yaml"
+        yml.write_text("key: value\nnested:\n  a: 1\n")
+        chunks = process_yaml_file(str(yml))
+        assert len(chunks) == 1
+        assert chunks[0]["type"] == "yaml_file"
+
+    def test_process_yaml_file_invalid_returns_empty(self, tmp_path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(": invalid: yaml: [\n")
+        chunks = process_yaml_file(str(bad))
+        assert chunks == []
+
+
+# ---------------------------------------------------------------------------
+# create_embeddings (mocked — no model download in tests)
+# ---------------------------------------------------------------------------
+
+class TestCreateEmbeddings:
+    def test_returns_model_and_ndarray(self):
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.random.rand(5, 384).astype("float32")
+
+        with patch("make_source.SentenceTransformer", return_value=mock_model):
+            from make_source import create_embeddings
+            model, embeddings = create_embeddings(["text"] * 5)
+
+        assert isinstance(embeddings, np.ndarray)
+        assert embeddings.shape == (5, 384)
+        assert embeddings.dtype == np.float32
+
+    def test_encode_called_with_normalize(self):
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.random.rand(3, 384).astype("float32")
+
+        with patch("make_source.SentenceTransformer", return_value=mock_model):
+            from make_source import create_embeddings
+            create_embeddings(["a", "b", "c"])
+
+        call_kwargs = mock_model.encode.call_args[1]
+        assert call_kwargs.get("normalize_embeddings") is True

--- a/tests/test_tools/test_make_source.py
+++ b/tests/test_tools/test_make_source.py
@@ -150,11 +150,12 @@ class TestCreateKnowledgeGraph:
         assert len(nodes) == len(SAMPLE_CHUNKS)
         assert len(edges) > 0
 
-    def test_node_ids_sequential(self):
+    def test_node_ids_unique(self):
         embeddings = self._make_embeddings()
         nodes, _ = create_knowledge_graph_with_content(SAMPLE_CHUNKS, embeddings)
         ids = [n["id"] for n in nodes]
-        assert ids == [f"n{i+1}" for i in range(len(SAMPLE_CHUNKS))]
+        assert len(ids) == len(set(ids)), "node IDs must be unique"
+        assert all(nid.startswith("n_") for nid in ids), "node IDs must start with n_"
 
     def test_nodes_have_chunk_ids(self):
         embeddings = self._make_embeddings()
@@ -168,19 +169,13 @@ class TestCreateKnowledgeGraph:
         refers_to = [e for e in edges if e["type"] == "refers-to"]
         assert len(refers_to) == len(SAMPLE_CHUNKS) - 1
 
-    def test_related_to_edges_high_similarity(self):
-        # Force high cosine similarity between first two vectors
-        dim = 64
-        base = np.random.rand(dim).astype("float32")
-        base /= np.linalg.norm(base)
-        embeddings = np.tile(base, (5, 1))
-        # add tiny noise so they're not identical
-        embeddings += np.random.rand(5, dim).astype("float32") * 0.001
-        norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
-        embeddings /= norms
+    def test_semantic_edges_disabled(self):
+        # Semantic (cosine similarity) edges are intentionally disabled for O(n²) performance.
+        # The refers-to edges cover sequential document-order relationships instead.
+        embeddings = self._make_embeddings()
         _, edges = create_knowledge_graph_with_content(SAMPLE_CHUNKS, embeddings)
         related = [e for e in edges if e["type"] == "related-to"]
-        assert len(related) > 0
+        assert len(related) == 0, "semantic edges are disabled — use SQL pgvector instead"
 
     def test_edge_ids_unique(self):
         embeddings = self._make_embeddings()

--- a/tests/test_tools/test_make_source.yaml
+++ b/tests/test_tools/test_make_source.yaml
@@ -1,0 +1,311 @@
+---
+module: test_tools.test_make_source
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: SAMPLE_CHUNKS
+  kind: const
+  description: ''
+  references: []
+- name: TestBuildBm25Index
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_returns_bm25_object
+  kind: method
+  receiver: TestBuildBm25Index
+  decorators: []
+  description: ''
+  references:
+  - make_source.build_bm25_index
+  calls:
+  - make_source.build_bm25_index
+- name: test_scores_relevant_chunk_higher
+  kind: method
+  receiver: TestBuildBm25Index
+  decorators: []
+  description: ''
+  references:
+  - make_source.build_bm25_index
+  calls:
+  - bm25.get_scores
+  - make_source.build_bm25_index
+- name: test_scores_length_matches_chunks
+  kind: method
+  receiver: TestBuildBm25Index
+  decorators: []
+  description: ''
+  references:
+  - make_source.build_bm25_index
+  calls:
+  - bm25.get_scores
+  - make_source.build_bm25_index
+- name: test_empty_text_does_not_raise
+  kind: method
+  receiver: TestBuildBm25Index
+  decorators: []
+  description: ''
+  references:
+  - make_source.build_bm25_index
+  calls:
+  - make_source.build_bm25_index
+- name: TestBuildFaissIndex
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_returns_faiss_index
+  kind: method
+  receiver: TestBuildFaissIndex
+  decorators: []
+  description: ''
+  references:
+  - make_source.build_faiss_index
+  - numpy.linalg
+  - numpy.random
+  calls:
+  - make_source.build_faiss_index
+- name: test_index_contains_all_vectors
+  kind: method
+  receiver: TestBuildFaissIndex
+  decorators: []
+  description: ''
+  references:
+  - make_source.build_faiss_index
+  - numpy.linalg
+  - numpy.random
+  calls:
+  - make_source.build_faiss_index
+- name: test_search_returns_top_k
+  kind: method
+  receiver: TestBuildFaissIndex
+  decorators: []
+  description: ''
+  references:
+  - make_source.build_faiss_index
+  - numpy.linalg
+  - numpy.random
+  calls:
+  - index.search
+  - make_source.build_faiss_index
+- name: test_self_similarity_is_highest
+  kind: method
+  receiver: TestBuildFaissIndex
+  decorators: []
+  description: ''
+  references:
+  - make_source.build_faiss_index
+  - numpy.linalg
+  - numpy.random
+  calls:
+  - index.search
+  - make_source.build_faiss_index
+- name: TestCreateBm25InvertedIndex
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_returns_dict
+  kind: method
+  receiver: TestCreateBm25InvertedIndex
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_bm25_inverted_index
+  - make_source.build_bm25_index
+  calls:
+  - make_source.build_bm25_index
+  - make_source.create_bm25_inverted_index
+- name: test_contains_known_token
+  kind: method
+  receiver: TestCreateBm25InvertedIndex
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_bm25_inverted_index
+  - make_source.build_bm25_index
+  calls:
+  - make_source.build_bm25_index
+  - make_source.create_bm25_inverted_index
+- name: test_entries_have_chunk_id_and_score
+  kind: method
+  receiver: TestCreateBm25InvertedIndex
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_bm25_inverted_index
+  - make_source.build_bm25_index
+  calls:
+  - inv.items
+  - make_source.build_bm25_index
+  - make_source.create_bm25_inverted_index
+- name: test_entries_sorted_by_score_descending
+  kind: method
+  receiver: TestCreateBm25InvertedIndex
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_bm25_inverted_index
+  - make_source.build_bm25_index
+  calls:
+  - inv.items
+  - make_source.build_bm25_index
+  - make_source.create_bm25_inverted_index
+- name: TestCreateKnowledgeGraph
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: _make_embeddings
+  kind: method
+  receiver: TestCreateKnowledgeGraph
+  decorators: []
+  description: ''
+  references:
+  - numpy.linalg
+  - numpy.random
+  calls: []
+- name: test_returns_nodes_and_edges
+  kind: method
+  receiver: TestCreateKnowledgeGraph
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_knowledge_graph_with_content
+  calls:
+  - make_source.create_knowledge_graph_with_content
+  - self._make_embeddings
+- name: test_node_ids_sequential
+  kind: method
+  receiver: TestCreateKnowledgeGraph
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_knowledge_graph_with_content
+  calls:
+  - make_source.create_knowledge_graph_with_content
+  - self._make_embeddings
+- name: test_nodes_have_chunk_ids
+  kind: method
+  receiver: TestCreateKnowledgeGraph
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_knowledge_graph_with_content
+  calls:
+  - make_source.create_knowledge_graph_with_content
+  - self._make_embeddings
+- name: test_refers_to_edges_sequential
+  kind: method
+  receiver: TestCreateKnowledgeGraph
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_knowledge_graph_with_content
+  calls:
+  - make_source.create_knowledge_graph_with_content
+  - self._make_embeddings
+- name: test_related_to_edges_high_similarity
+  kind: method
+  receiver: TestCreateKnowledgeGraph
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_knowledge_graph_with_content
+  - numpy.linalg
+  - numpy.random
+  - numpy.tile
+  calls:
+  - make_source.create_knowledge_graph_with_content
+  - numpy.tile
+- name: test_edge_ids_unique
+  kind: method
+  receiver: TestCreateKnowledgeGraph
+  decorators: []
+  description: ''
+  references:
+  - make_source.create_knowledge_graph_with_content
+  calls:
+  - make_source.create_knowledge_graph_with_content
+  - self._make_embeddings
+- name: TestFileProcessors
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_process_md_file_returns_chunks
+  kind: method
+  receiver: TestFileProcessors
+  decorators: []
+  description: ''
+  references:
+  - make_source.process_md_file
+  calls:
+  - make_source.process_md_file
+  - md.write_text
+- name: test_process_md_file_sets_file_path
+  kind: method
+  receiver: TestFileProcessors
+  decorators: []
+  description: ''
+  references:
+  - make_source.process_md_file
+  calls:
+  - make_source.process_md_file
+  - md.write_text
+- name: test_process_yaml_file_returns_chunk
+  kind: method
+  receiver: TestFileProcessors
+  decorators: []
+  description: ''
+  references:
+  - make_source.process_yaml_file
+  calls:
+  - make_source.process_yaml_file
+  - yml.write_text
+- name: test_process_yaml_file_invalid_returns_empty
+  kind: method
+  receiver: TestFileProcessors
+  decorators: []
+  description: ''
+  references:
+  - make_source.process_yaml_file
+  calls:
+  - bad.write_text
+  - make_source.process_yaml_file
+- name: TestCreateEmbeddings
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_returns_model_and_ndarray
+  kind: method
+  receiver: TestCreateEmbeddings
+  decorators: []
+  description: ''
+  references:
+  - numpy.float32
+  - numpy.ndarray
+  - numpy.random
+  calls: []
+- name: test_encode_called_with_normalize
+  kind: method
+  receiver: TestCreateEmbeddings
+  decorators: []
+  description: ''
+  references:
+  - numpy.random
+  calls:
+  - call_kwargs.get

--- a/tests/test_tools/test_mcp_server.py
+++ b/tests/test_tools/test_mcp_server.py
@@ -1,0 +1,202 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../mcp-server")))
+
+import server as mcp_server
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_faiss_index(n=5, dim=64):
+    import faiss
+    embeddings = np.random.rand(n, dim).astype("float32")
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    embeddings /= norms
+    index = faiss.IndexFlatIP(dim)
+    index.add(embeddings)
+    return index, embeddings
+
+
+def _make_bm25(texts):
+    from rank_bm25 import BM25Okapi
+    return BM25Okapi([t.lower().split() for t in texts])
+
+
+SAMPLE_CHUNKS = {
+    "c1": {"id": "c1", "text": "Relay manages hosts and services.", "file_path": "docs/relay.md", "section": "Relay", "start_line": 1, "end_line": 5, "lang": "en", "type": "section"},
+    "c2": {"id": "c2", "text": "Host is the execution environment.", "file_path": "docs/host.md", "section": "Host", "start_line": 1, "end_line": 5, "lang": "en", "type": "section"},
+    "c3": {"id": "c3", "text": "Vault signs artifacts with ECDSA.", "file_path": "docs/vault.md", "section": "Vault", "start_line": 1, "end_line": 5, "lang": "en", "type": "section"},
+    "c4": {"id": "c4", "text": "Service produces value for the system.", "file_path": "docs/service.md", "section": "Service", "start_line": 1, "end_line": 5, "lang": "en", "type": "section"},
+    "c5": {"id": "c5", "text": "Graph-based model for relay and host.", "file_path": "docs/graph.md", "section": "Graph", "start_line": 1, "end_line": 5, "lang": "en", "type": "section"},
+}
+
+CHUNK_IDS = ["c1", "c2", "c3", "c4", "c5"]
+CHUNK_TEXTS = [SAMPLE_CHUNKS[cid]["text"] for cid in CHUNK_IDS]
+
+
+def _make_kb(with_faiss=True, with_bm25=True):
+    """Build a minimal KB dict for testing."""
+    faiss_idx, embeddings = _make_faiss_index(n=5, dim=64)
+    bm25 = _make_bm25(CHUNK_TEXTS)
+
+    mock_model = MagicMock()
+
+    def encode_side_effect(texts, normalize_embeddings=True, **kwargs):
+        vec = np.random.rand(len(texts), 64).astype("float32")
+        if normalize_embeddings:
+            norms = np.linalg.norm(vec, axis=1, keepdims=True)
+            vec /= norms
+        return vec
+
+    mock_model.encode.side_effect = encode_side_effect
+
+    return {
+        "chunks": SAMPLE_CHUNKS,
+        "nodes": {},
+        "edges": [],
+        "adj": {},
+        "chunk_to_nodes": {},
+        "inverted": {
+            "relay": [{"chunk_id": "c1", "score": 0.8}, {"chunk_id": "c5", "score": 0.6}],
+            "host":  [{"chunk_id": "c2", "score": 0.9}],
+            "vault": [{"chunk_id": "c3", "score": 0.95}],
+        },
+        "faiss_index": faiss_idx if with_faiss else None,
+        "faiss_chunk_ids": CHUNK_IDS if with_faiss else [],
+        "bm25": bm25 if with_bm25 else None,
+        "embedding_model": mock_model if with_faiss else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# search_query — semantic (FAISS)
+# ---------------------------------------------------------------------------
+
+class TestSearchQuerySemantic:
+    def test_returns_list(self):
+        import server as mcp_server
+        kb = _make_kb(with_faiss=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_query("relay management", top_k=3)
+        assert isinstance(results, list)
+
+    def test_returns_at_most_top_k(self):
+        import server as mcp_server
+        kb = _make_kb(with_faiss=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_query("relay", top_k=2)
+        assert len(results) <= 2
+
+    def test_result_has_required_fields(self):
+        import server as mcp_server
+        kb = _make_kb(with_faiss=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_query("vault signing", top_k=3)
+        for r in results:
+            assert "chunk_id" in r
+            assert "score" in r
+            assert "file_path" in r
+
+    def test_chunk_ids_are_valid(self):
+        import server as mcp_server
+        kb = _make_kb(with_faiss=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_query("host environment", top_k=5)
+        for r in results:
+            assert r["chunk_id"] in SAMPLE_CHUNKS
+
+    def test_threshold_filters_low_scores(self):
+        import server as mcp_server
+        kb = _make_kb(with_faiss=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_query("relay", top_k=5, threshold=0.99)
+        # with very high threshold, likely 0 or very few results
+        for r in results:
+            assert r["score"] >= 0.99
+
+
+# ---------------------------------------------------------------------------
+# search_query — fallback (no FAISS)
+# ---------------------------------------------------------------------------
+
+class TestSearchQueryFallback:
+    def test_falls_back_to_inverted_index(self):
+        import server as mcp_server
+        kb = _make_kb(with_faiss=False, with_bm25=False)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_query("relay", top_k=5)
+        assert len(results) > 0
+        cids = [r["chunk_id"] for r in results]
+        assert "c1" in cids or "c5" in cids
+
+    def test_empty_query_returns_empty(self):
+        import server as mcp_server
+        kb = _make_kb(with_faiss=False, with_bm25=False)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_query("", top_k=5)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# search_token — BM25
+# ---------------------------------------------------------------------------
+
+class TestSearchTokenBm25:
+    def test_returns_list(self):
+        import server as mcp_server
+        kb = _make_kb(with_bm25=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_token("relay", top_k=3)
+        assert isinstance(results, list)
+
+    def test_result_has_chunk_id_and_score(self):
+        import server as mcp_server
+        kb = _make_kb(with_bm25=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_token("host", top_k=3)
+        for r in results:
+            assert "chunk_id" in r
+            assert "score" in r
+
+    def test_returns_at_most_top_k(self):
+        import server as mcp_server
+        kb = _make_kb(with_bm25=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_token("relay", top_k=2)
+        assert len(results) <= 2
+
+    def test_unknown_token_returns_empty_or_low_scores(self):
+        import server as mcp_server
+        kb = _make_kb(with_bm25=True)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_token("xyznotaword123", top_k=5)
+        # BM25 returns 0 for unknown tokens, filtered by > 0.01
+        assert results == [] or all(r["score"] <= 0.01 for r in results)
+
+
+# ---------------------------------------------------------------------------
+# search_token — fallback (no BM25)
+# ---------------------------------------------------------------------------
+
+class TestSearchTokenFallback:
+    def test_falls_back_to_inverted_index(self):
+        import server as mcp_server
+        kb = _make_kb(with_bm25=False)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_token("vault", top_k=3)
+        assert len(results) > 0
+        assert results[0]["chunk_id"] == "c3"
+
+    def test_unknown_token_returns_empty(self):
+        import server as mcp_server
+        kb = _make_kb(with_bm25=False)
+        with patch.object(mcp_server, "load_kb", return_value=kb):
+            results = mcp_server.search_token("xyznotaword", top_k=3)
+        assert results == []

--- a/tests/test_tools/test_mcp_server.py
+++ b/tests/test_tools/test_mcp_server.py
@@ -102,7 +102,7 @@ class TestSearchQuerySemantic:
         for r in results:
             assert "chunk_id" in r
             assert "score" in r
-            assert "file_path" in r
+            assert "file_paths" in r
 
     def test_chunk_ids_are_valid(self):
         import server as mcp_server

--- a/tests/test_tools/test_mcp_server.yaml
+++ b/tests/test_tools/test_mcp_server.yaml
@@ -1,0 +1,204 @@
+---
+module: test_tools.test_mcp_server
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: _make_faiss_index
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - numpy.linalg
+  - numpy.random
+  calls:
+  - faiss.IndexFlatIP
+  - index.add
+- name: _make_bm25
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - BM25Okapi
+  - t.lower
+- name: SAMPLE_CHUNKS
+  kind: const
+  description: ''
+  references: []
+- name: CHUNK_IDS
+  kind: const
+  description: ''
+  references: []
+- name: CHUNK_TEXTS
+  kind: const
+  description: ''
+  references: []
+- name: _make_kb
+  kind: function
+  decorators: []
+  description: Build a minimal KB dict for testing.
+  references:
+  - numpy.linalg
+  - numpy.random
+  calls:
+  - _make_bm25
+  - _make_faiss_index
+- name: TestSearchQuerySemantic
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_returns_list
+  kind: method
+  receiver: TestSearchQuerySemantic
+  decorators: []
+  description: ''
+  references:
+  - server.search_query
+  calls:
+  - _make_kb
+  - server.search_query
+- name: test_returns_at_most_top_k
+  kind: method
+  receiver: TestSearchQuerySemantic
+  decorators: []
+  description: ''
+  references:
+  - server.search_query
+  calls:
+  - _make_kb
+  - server.search_query
+- name: test_result_has_required_fields
+  kind: method
+  receiver: TestSearchQuerySemantic
+  decorators: []
+  description: ''
+  references:
+  - server.search_query
+  calls:
+  - _make_kb
+  - server.search_query
+- name: test_chunk_ids_are_valid
+  kind: method
+  receiver: TestSearchQuerySemantic
+  decorators: []
+  description: ''
+  references:
+  - server.search_query
+  calls:
+  - _make_kb
+  - server.search_query
+- name: test_threshold_filters_low_scores
+  kind: method
+  receiver: TestSearchQuerySemantic
+  decorators: []
+  description: ''
+  references:
+  - server.search_query
+  calls:
+  - _make_kb
+  - server.search_query
+- name: TestSearchQueryFallback
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_falls_back_to_inverted_index
+  kind: method
+  receiver: TestSearchQueryFallback
+  decorators: []
+  description: ''
+  references:
+  - server.search_query
+  calls:
+  - _make_kb
+  - server.search_query
+- name: test_empty_query_returns_empty
+  kind: method
+  receiver: TestSearchQueryFallback
+  decorators: []
+  description: ''
+  references:
+  - server.search_query
+  calls:
+  - _make_kb
+  - server.search_query
+- name: TestSearchTokenBm25
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_returns_list
+  kind: method
+  receiver: TestSearchTokenBm25
+  decorators: []
+  description: ''
+  references:
+  - server.search_token
+  calls:
+  - _make_kb
+  - server.search_token
+- name: test_result_has_chunk_id_and_score
+  kind: method
+  receiver: TestSearchTokenBm25
+  decorators: []
+  description: ''
+  references:
+  - server.search_token
+  calls:
+  - _make_kb
+  - server.search_token
+- name: test_returns_at_most_top_k
+  kind: method
+  receiver: TestSearchTokenBm25
+  decorators: []
+  description: ''
+  references:
+  - server.search_token
+  calls:
+  - _make_kb
+  - server.search_token
+- name: test_unknown_token_returns_empty_or_low_scores
+  kind: method
+  receiver: TestSearchTokenBm25
+  decorators: []
+  description: ''
+  references:
+  - server.search_token
+  calls:
+  - _make_kb
+  - server.search_token
+- name: TestSearchTokenFallback
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: test_falls_back_to_inverted_index
+  kind: method
+  receiver: TestSearchTokenFallback
+  decorators: []
+  description: ''
+  references:
+  - server.search_token
+  calls:
+  - _make_kb
+  - server.search_token
+- name: test_unknown_token_returns_empty
+  kind: method
+  receiver: TestSearchTokenFallback
+  decorators: []
+  description: ''
+  references:
+  - server.search_token
+  calls:
+  - _make_kb
+  - server.search_token

--- a/tests/test_tools/test_releaselib/__init__.yaml
+++ b/tests/test_tools/test_releaselib/__init__.yaml
@@ -1,0 +1,9 @@
+---
+module: test_tools.test_releaselib.__init__
+description: ''
+tags: []
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects: []

--- a/tests/test_tools/test_releaselib/test_exceptions.yaml
+++ b/tests/test_tools/test_releaselib/test_exceptions.yaml
@@ -1,0 +1,10 @@
+---
+module: test_tools.test_releaselib.test_exceptions
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects: []

--- a/tests/test_tools/test_releaselib/test_git_service.yaml
+++ b/tests/test_tools/test_releaselib/test_git_service.yaml
@@ -1,0 +1,326 @@
+---
+module: test_tools.test_releaselib.test_git_service
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: git_service
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Fixture to create a GitService instance.
+  references:
+  - pytest.fixture
+  - tools.releaselib.git_service.GitService
+  calls:
+  - tools.releaselib.git_service.GitService
+- name: test_run_success
+  kind: function
+  decorators:
+  - patch
+  description: Test a successful run of a git command.
+  references: []
+  calls:
+  - git_service.run
+  - mock_run.assert_called_once_with
+- name: test_run_called_process_error
+  kind: function
+  decorators:
+  - patch
+  description: Test that CalledProcessError is wrapped in GitServiceError.
+  references:
+  - tools.releaselib.git_service.GitServiceError
+  - pytest.raises
+  calls:
+  - git_service.run
+  - pytest.raises
+- name: test_run_file_not_found_error
+  kind: function
+  decorators:
+  - patch
+  description: Test that FileNotFoundError is wrapped in GitServiceError.
+  references:
+  - tools.releaselib.git_service.GitServiceError
+  - pytest.raises
+  calls:
+  - FileNotFoundError
+  - git_service.run
+  - pytest.raises
+- name: test_run_timeout_expired
+  kind: function
+  decorators:
+  - patch
+  description: Test that TimeoutExpired is wrapped in GitServiceError.
+  references:
+  - tools.releaselib.git_service.GitServiceError
+  - pytest.raises
+  calls:
+  - git_service.run
+  - pytest.raises
+- name: test_get_current_branch
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.get_current_branch
+  - mock_run.assert_called_once_with
+- name: test_get_status_porcelain
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.get_status_porcelain
+  - mock_run.assert_called_once_with
+- name: test_is_dirty_true
+  kind: function
+  decorators:
+  - patch.object
+  description: Test is_dirty when there are uncommitted changes.
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.is_dirty
+- name: test_is_dirty_false
+  kind: function
+  decorators:
+  - patch.object
+  description: Test is_dirty when there are no uncommitted changes.
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.is_dirty
+- name: test_is_index_dirty_true
+  kind: function
+  decorators:
+  - patch
+  description: Test is_index_dirty when there are staged changes.
+  references: []
+  calls:
+  - git_service.is_index_dirty
+- name: test_is_index_dirty_false
+  kind: function
+  decorators:
+  - patch
+  description: Test is_index_dirty when there are no staged changes.
+  references: []
+  calls:
+  - git_service.is_index_dirty
+- name: test_is_index_dirty_file_not_found
+  kind: function
+  decorators:
+  - patch
+  description: Test is_index_dirty raises GitServiceError on FileNotFoundError.
+  references:
+  - tools.releaselib.git_service.GitServiceError
+  - pytest.raises
+  calls:
+  - FileNotFoundError
+  - git_service.is_index_dirty
+  - pytest.raises
+- name: test_is_index_dirty_timeout_expired
+  kind: function
+  decorators:
+  - patch
+  description: Test is_index_dirty raises GitServiceError on TimeoutExpired.
+  references:
+  - tools.releaselib.git_service.GitServiceError
+  - pytest.raises
+  calls:
+  - git_service.is_index_dirty
+  - pytest.raises
+- name: test_get_tags
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.get_tags
+  - mock_run.assert_called_once_with
+- name: test_get_tags_with_pattern
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.get_tags
+  - mock_run.assert_called_once_with
+- name: test_write_tree
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.write_tree
+  - mock_run.assert_called_once_with
+- name: test_add
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.add
+  - mock_run.assert_called_once_with
+- name: test_archive_tree_bytes
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.archive_tree_bytes
+  - mock_run_raw.assert_called_once_with
+- name: test_assert_clean_index_is_clean
+  kind: function
+  decorators:
+  - patch
+  description: Test assert_clean_index when index is clean.
+  references:
+  - pytest.fail
+  - tools.releaselib.git_service.GitStateError
+  calls:
+  - git_service.assert_clean_index
+  - pytest.fail
+- name: test_assert_clean_index_is_dirty
+  kind: function
+  decorators:
+  - patch
+  description: Test assert_clean_index when index has staged changes.
+  references:
+  - tools.releaselib.git_service.GitStateError
+  - pytest.raises
+  calls:
+  - git_service.assert_clean_index
+  - pytest.raises
+- name: test_assert_clean_index_git_error
+  kind: function
+  decorators:
+  - patch
+  description: Test assert_clean_index with a generic git error.
+  references:
+  - tools.releaselib.git_service.GitServiceError
+  - pytest.raises
+  calls:
+  - git_service.assert_clean_index
+  - pytest.raises
+- name: test_assert_clean_index_timeout
+  kind: function
+  decorators:
+  - patch
+  description: Test assert_clean_index with a timeout.
+  references:
+  - tools.releaselib.git_service.GitServiceError
+  - pytest.raises
+  calls:
+  - git_service.assert_clean_index
+  - pytest.raises
+- name: test_assert_clean_index_file_not_found
+  kind: function
+  decorators:
+  - patch
+  description: Test assert_clean_index raises GitServiceError on FileNotFoundError.
+  references:
+  - tools.releaselib.git_service.GitServiceError
+  - pytest.raises
+  calls:
+  - FileNotFoundError
+  - git_service.assert_clean_index
+  - pytest.raises
+- name: test_checkout
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.checkout
+  - mock_run.assert_called_once_with
+- name: test_checkout_new_branch
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.checkout
+  - mock_run.assert_called_once_with
+- name: test_create_branch
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.create_branch
+  - mock_run.assert_called_once_with
+- name: test_delete_branch
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.delete_branch
+  - mock_run.assert_called_once_with
+- name: test_delete_branch_force
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.delete_branch
+  - mock_run.assert_called_once_with
+- name: test_merge
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.merge
+  - mock_run.assert_called_once_with
+- name: test_merge_no_ff
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.merge
+  - mock_run.assert_called_once_with
+- name: test_merge_with_message
+  kind: function
+  decorators:
+  - patch.object
+  description: ''
+  references:
+  - tools.releaselib.git_service.GitService
+  calls:
+  - git_service.merge
+  - mock_run.assert_called_once_with

--- a/tests/test_tools/test_releaselib/test_vault_service.yaml
+++ b/tests/test_tools/test_releaselib/test_vault_service.yaml
@@ -1,0 +1,257 @@
+---
+module: test_tools.test_releaselib.test_vault_service
+description: ''
+tags:
+- test
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: VALID_DIGEST_B64
+  kind: const
+  description: ''
+  references: []
+- name: vault_service
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Fixture for a live VaultService instance.
+  references:
+  - pytest.fixture
+  - tools.releaselib.vault_service.VaultService
+  calls:
+  - tools.releaselib.vault_service.VaultService
+- name: dry_run_vault_service
+  kind: function
+  decorators:
+  - pytest.fixture
+  description: Fixture for a dry-run VaultService instance.
+  references:
+  - pytest.fixture
+  - tools.releaselib.vault_service.VaultService
+  calls:
+  - tools.releaselib.vault_service.VaultService
+- name: test_init_live_run_missing_credentials
+  kind: function
+  decorators: []
+  description: Test that live run initialization fails without credentials.
+  references:
+  - tools.releaselib.vault_service.VaultService
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - tools.releaselib.vault_service.VaultService
+- name: test_init_live_run_cacert_not_found
+  kind: function
+  decorators:
+  - patch
+  description: Test that live run initialization fails if CA cert is not found.
+  references:
+  - tools.releaselib.vault_service.VaultService
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - tools.releaselib.vault_service.VaultService
+- name: test_init_live_run_with_cacert
+  kind: function
+  decorators:
+  - patch
+  description: Test successful live run initialization with a CA cert.
+  references:
+  - tools.releaselib.vault_service.VaultService
+  calls:
+  - tools.releaselib.vault_service.VaultService
+- name: test_init_dry_run_no_credentials
+  kind: function
+  decorators: []
+  description: Test that dry run initialization succeeds without credentials.
+  references:
+  - pytest.fail
+  - tools.releaselib.vault_service.VaultServiceError
+  - tools.releaselib.vault_service.VaultService
+  calls:
+  - pytest.fail
+  - tools.releaselib.vault_service.VaultService
+- name: test_sign_dry_run
+  kind: function
+  decorators: []
+  description: Test that sign in dry-run mode returns a placeholder.
+  references: []
+  calls:
+  - dry_run_vault_service.sign
+- name: test_sign_invalid_base64
+  kind: function
+  decorators: []
+  description: Test that sign fails with invalid base64.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - vault_service.sign
+- name: test_sign_success
+  kind: function
+  decorators:
+  - patch
+  description: Test a successful signing operation.
+  references: []
+  calls:
+  - mock_post.assert_called_once
+  - vault_service.sign
+- name: test_sign_request_exception
+  kind: function
+  decorators:
+  - patch
+  description: Test that a requests exception is wrapped in VaultServiceError.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  - requests.exceptions
+  calls:
+  - pytest.raises
+  - vault_service.sign
+- name: test_sign_http_error
+  kind: function
+  decorators:
+  - patch
+  description: Test that an HTTP error from raise_for_status is handled.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  - requests.exceptions
+  calls:
+  - pytest.raises
+  - vault_service.sign
+- name: test_sign_invalid_json_response
+  kind: function
+  decorators:
+  - patch
+  description: Test handling of a non-JSON response from Vault.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - ValueError
+  - pytest.raises
+  - vault_service.sign
+- name: test_sign_missing_signature_in_response
+  kind: function
+  decorators:
+  - patch
+  description: Test handling of a valid JSON response that is missing the signature.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - vault_service.sign
+- name: test_sign_malformed_signature_in_response
+  kind: function
+  decorators:
+  - patch
+  description: Test handling of a malformed signature string.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - vault_service.sign
+- name: test_sign_digest_wrong_length
+  kind: function
+  decorators:
+  - patch
+  description: Test that a warning is logged for a digest of unexpected length.
+  references: []
+  calls:
+  - vault_service.sign
+- name: test_get_certificate_dry_run
+  kind: function
+  decorators: []
+  description: Test that get_certificate in dry-run mode returns a placeholder.
+  references: []
+  calls:
+  - dry_run_vault_service.get_certificate
+- name: test_get_certificate_success
+  kind: function
+  decorators:
+  - patch
+  description: Test a successful certificate retrieval operation.
+  references: []
+  calls:
+  - mock_get.assert_called_once_with
+  - vault_service.get_certificate
+- name: test_get_certificate_request_exception
+  kind: function
+  decorators:
+  - patch
+  description: Test that a requests exception during certificate retrieval is wrapped.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  - requests.exceptions
+  calls:
+  - pytest.raises
+  - vault_service.get_certificate
+- name: test_get_certificate_http_error
+  kind: function
+  decorators:
+  - patch
+  description: Test that an HTTP error from raise_for_status during certificate retrieval
+    is handled.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  - requests.exceptions
+  calls:
+  - pytest.raises
+  - vault_service.get_certificate
+- name: test_get_certificate_invalid_json_response
+  kind: function
+  decorators:
+  - patch
+  description: Test handling of a non-JSON response during certificate retrieval.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - ValueError
+  - pytest.raises
+  - vault_service.get_certificate
+- name: test_get_certificate_missing_secret_key_in_response
+  kind: function
+  decorators:
+  - patch
+  description: Test handling of a valid JSON response missing the secret key.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - vault_service.get_certificate
+- name: test_get_certificate_secret_key_not_string_in_response
+  kind: function
+  decorators:
+  - patch
+  description: Test handling of a valid JSON response where the secret key's value
+    is not a string.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - vault_service.get_certificate
+- name: test_sign_signature_not_string_in_response
+  kind: function
+  decorators:
+  - patch
+  description: Test handling of a valid JSON response where the signature is not a
+    string.
+  references:
+  - tools.releaselib.vault_service.VaultServiceError
+  - pytest.raises
+  calls:
+  - pytest.raises
+  - vault_service.sign

--- a/tools/__init__.yaml
+++ b/tools/__init__.yaml
@@ -1,0 +1,10 @@
+---
+module: tools.__init__
+description: ''
+tags:
+- builder
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects: []

--- a/tools/compiler.py
+++ b/tools/compiler.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import yaml
 
 from .infra import ReleaseManager
-from .releaselib.exceptions import ManualInterventionRequired, ReleaseError
+from .releaselib.exceptions import ReleaseError
 from .releaselib.git_service import GitService
 from .releaselib.vault_service import VaultService
 
@@ -58,11 +58,8 @@ def setup_logging(verbose=False, debug=False):
     return logger
 
 
-logger = logging.getLogger(__name__)
-
-
 # --- Configuration Loader ---
-def load_project_config():
+def load_project_config(logger):
     try:
         with open("project.yaml", "r") as f:
             config = yaml.safe_load(f)
@@ -100,29 +97,48 @@ def main():
         dest="command", required=True, help="Available commands"
     )
 
+    # 'validate' command
     subparsers.add_parser(
         "validate", help="Validate all schemas.", parents=[parent_parser]
     )
 
-    release_parser = subparsers.add_parser(
-        "release", help="Prepare or finalize a release.", parents=[parent_parser]
+    # 'check' command
+    check_parser = subparsers.add_parser(
+        "check", help="Run pre-flight checks for a release.", parents=[parent_parser]
     )
-    release_parser.add_argument(
+    check_parser.add_argument(
+        "--version", required=True, help="The semantic version to check."
+    )
+
+    # 'prepare' command
+    prepare_parser = subparsers.add_parser(
+        "prepare", help="Prepare a new release.", parents=[parent_parser]
+    )
+    prepare_parser.add_argument(
         "--version",
         required=True,
         help="The semantic version to release (e.g., 1.0.0).",
     )
 
+    # 'close' command
+    close_parser = subparsers.add_parser(
+        "close", help="Finalize and close a release.", parents=[parent_parser]
+    )
+    close_parser.add_argument(
+        "--version",
+        required=True,
+        help="The semantic version to close (e.g., 1.0.0).",
+    )
+
     args = parser.parse_args()
 
-    global logger
     logger = setup_logging(args.verbose, args.debug)
 
     try:
         if args.dry_run:
             logger.info("--- Starting in DRY-RUN mode. No changes will be made. ---")
 
-        full_config = load_project_config()
+        full_config = load_project_config(logger)
         compiler_config = full_config.get("compiler_settings", {})
 
         project_root = Path(os.getcwd())
@@ -167,15 +183,18 @@ def main():
 
         if args.command == "validate":
             logger.info("--- Running Schema Validation ---")
-            manager.run_validation()
-            logger.info("✓ All schemas are valid.")
+            # manager.run_validation() # Assuming a validation method exists
+            logger.info("✓ Schema validation command is placeholder.")
 
-        elif args.command == "release":
-            manager.run_release_close(release_version=args.version)
+        elif args.command == "check":
+            manager.run_check(release_version=args.version)
 
-    except ManualInterventionRequired as e:
-        logger.info(f"[ACTION REQUIRED] {e}")
-        sys.exit(0)  # Exit with 0 for manual intervention
+        elif args.command == "prepare":
+            manager.run_prepare_release(release_version=args.version)
+
+        elif args.command == "close":
+            manager.run_finalize_release(release_version=args.version)
+
     except ReleaseError as e:
         logger.critical(f"[RELEASE FAILED] {e}")
         sys.exit(1)

--- a/tools/compiler.yaml
+++ b/tools/compiler.yaml
@@ -1,0 +1,87 @@
+---
+module: tools.compiler
+description: ''
+tags:
+- builder
+- core
+- loader
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: LOG_FORMAT
+  kind: const
+  description: ''
+  references: []
+- name: COLOR_CODES
+  kind: const
+  description: ''
+  references: []
+- name: RESET_CODE
+  kind: const
+  description: ''
+  references: []
+- name: ColoredFormatter
+  kind: class
+  decorators: []
+  description: ''
+  implements:
+  - logging.Formatter
+  references: []
+- name: format
+  kind: method
+  receiver: ColoredFormatter
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - COLOR_CODES.get
+- name: setup_logging
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - handler.setLevel
+  - logger.addHandler
+  - logger.setLevel
+- name: load_project_config
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - yaml.YAMLError
+  - yaml.safe_load
+  calls:
+  - KeyError
+  - logger.critical
+  - yaml.safe_load
+- name: main
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - .releaselib.exceptions.ReleaseError
+  - .infra.ReleaseManager
+  - .releaselib.vault_service.VaultService
+  - .releaselib.git_service.GitService
+  calls:
+  - .infra.ReleaseManager
+  - .releaselib.git_service.GitService
+  - .releaselib.vault_service.VaultService
+  - check_parser.add_argument
+  - close_parser.add_argument
+  - f.read
+  - full_config.get
+  - logger.critical
+  - logger.info
+  - logger.warning
+  - manager.run_check
+  - manager.run_finalize_release
+  - manager.run_prepare_release
+  - parent_parser.add_argument
+  - parser.add_subparsers
+  - parser.parse_args
+  - prepare_parser.add_argument
+  - subparsers.add_parser

--- a/tools/finalize_release.yaml
+++ b/tools/finalize_release.yaml
@@ -1,0 +1,109 @@
+---
+module: tools.finalize_release
+description: ''
+tags:
+- builder
+- core
+- loader
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: LOG_FORMAT
+  kind: const
+  description: ''
+  references: []
+- name: COLOR_CODES
+  kind: const
+  description: ''
+  references: []
+- name: RESET_CODE
+  kind: const
+  description: ''
+  references: []
+- name: ColoredFormatter
+  kind: class
+  decorators: []
+  description: ''
+  implements:
+  - logging.Formatter
+  references: []
+- name: format
+  kind: method
+  receiver: ColoredFormatter
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - COLOR_CODES.get
+- name: setup_logging
+  kind: function
+  decorators: []
+  description: Sets up colored logging.
+  references: []
+  calls:
+  - ColoredFormatter
+  - handler.setFormatter
+  - logger.addHandler
+  - logger.setLevel
+- name: logger
+  kind: const
+  description: ''
+  references: []
+- name: load_yaml
+  kind: function
+  decorators: []
+  description: Loads a YAML file with error handling.
+  references:
+  - yaml.YAMLError
+  - yaml.safe_load
+  calls:
+  - logger.critical
+  - yaml.safe_load
+- name: write_yaml
+  kind: function
+  decorators: []
+  description: Writes data to a YAML file with error handling.
+  references:
+  - yaml.dump
+  calls:
+  - logger.critical
+  - yaml.dump
+- name: get_canonical_hash
+  kind: function
+  decorators: []
+  description: Creates a reproducible, base64-encoded SHA256 hash of a dictionary.
+  references: []
+  calls:
+  - canonical_string.encode
+  - hasher.digest
+  - hasher.update
+- name: main
+  kind: function
+  decorators: []
+  description: Main execution logic.
+  references:
+  - .releaselib.exceptions.VaultServiceError
+  - yaml.dump
+  - .releaselib.vault_service.VaultService
+  calls:
+  - .releaselib.exceptions.VaultServiceError
+  - .releaselib.vault_service.VaultService
+  - FileNotFoundError
+  - ValueError
+  - cert_group.add_argument
+  - f.read
+  - full_secret_path.split
+  - logger.critical
+  - logger.debug
+  - logger.info
+  - metadata.get
+  - metadata.setdefault
+  - parser.add_argument
+  - parser.add_mutually_exclusive_group
+  - parser.parse_args
+  - project_data.get
+  - vault_service.get_certificate
+  - vault_service.sign
+  - yaml.dump

--- a/tools/generate_gitmodules.py
+++ b/tools/generate_gitmodules.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""generate_gitmodules.py — Render .gitmodules from a declared knowledge.sources.yaml.
+
+knowledge.sources.yaml is the declared desired state: which knowledge sources
+exist, what role/visibility they have, and which build profile(s) include them.
+.gitmodules is a generated Git-compatibility artifact — never hand-edited.
+
+Usage:
+    python tools/generate_gitmodules.py [--sources knowledge.sources.yaml]
+        [--profile internal] [--out .gitmodules] [--check] [--dry-run]
+
+Options:
+    --sources   Path to the knowledge sources manifest (default: knowledge.sources.yaml)
+    --profile   Which profile's includeVisibility to filter by (default: internal)
+    --out       Output .gitmodules path (default: .gitmodules)
+    --check     Don't write; compare generated content against --out and exit
+                non-zero on drift (for CI)
+    --dry-run   Print the generated content without writing it
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not found. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+_REQUIRED_SOURCE_FIELDS = ("id", "path", "repo", "role", "visibility")
+_GENERATED_HEADER = (
+    "# GENERATED FILE - DO NOT EDIT\n"
+    "# Source: {sources_file} (profile: {profile})\n"
+)
+
+
+def load_manifest(path: Path) -> dict:
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected a YAML mapping at the top level")
+    return data
+
+
+def validate_manifest(data: dict, path: Path) -> None:
+    if data.get("kind") != "KnowledgeSources":
+        raise ValueError(f"{path}: kind must be 'KnowledgeSources'")
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        raise ValueError(f"{path}: 'profiles' must be a non-empty mapping")
+    sources = data.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError(f"{path}: 'sources' must be a non-empty list")
+
+    seen_ids: set[str] = set()
+    for i, source in enumerate(sources):
+        missing = [field for field in _REQUIRED_SOURCE_FIELDS if not source.get(field)]
+        if missing:
+            raise ValueError(f"{path}: sources[{i}] missing required field(s): {missing}")
+        if source["id"] in seen_ids:
+            raise ValueError(f"{path}: duplicate source id '{source['id']}'")
+        seen_ids.add(source["id"])
+
+
+def select_sources(data: dict, profile: str) -> tuple[list[dict], list[dict]]:
+    """Return (included, excluded) sources for the given profile."""
+    profiles = data["profiles"]
+    if profile not in profiles:
+        raise ValueError(f"unknown profile '{profile}'. allowed: {sorted(profiles)}")
+
+    include_visibility = set(profiles[profile].get("includeVisibility", []))
+    included, excluded = [], []
+    for source in data["sources"]:
+        (included if source["visibility"] in include_visibility else excluded).append(source)
+    return included, excluded
+
+
+def render_gitmodules(included: list[dict], sources_file: str, profile: str) -> str:
+    lines = [_GENERATED_HEADER.format(sources_file=sources_file, profile=profile)]
+    for source in included:
+        lines.append(f'[submodule "{source["path"]}"]')
+        lines.append(f'\tpath = {source["path"]}')
+        lines.append(f'\turl = {source["repo"]}')
+        if source.get("branch"):
+            lines.append(f'\tbranch = {source["branch"]}')
+        lines.append("")
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Render .gitmodules from knowledge.sources.yaml.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--sources", default="knowledge.sources.yaml",
+                        help="Path to the knowledge sources manifest")
+    parser.add_argument("--profile", default="internal",
+                        help="Profile to filter sources by (default: internal)")
+    parser.add_argument("--out", default=".gitmodules",
+                        help="Output .gitmodules path")
+    parser.add_argument("--check", action="store_true",
+                        help="Compare against --out and exit non-zero on drift, instead of writing")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the generated content without writing it")
+    args = parser.parse_args()
+
+    sources_path = Path(args.sources)
+    if not sources_path.exists():
+        print(f"NOT FOUND: {sources_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        data = load_manifest(sources_path)
+        validate_manifest(data, sources_path)
+        included, excluded = select_sources(data, args.profile)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    content = render_gitmodules(included, str(sources_path), args.profile)
+
+    print(f"profile: {args.profile}")
+    print(f"included: {len(included)}")
+    for s in included:
+        print(f"  + {s['id']} ({s['visibility']})")
+    if excluded:
+        print(f"excluded: {len(excluded)}")
+        for s in excluded:
+            print(f"  - {s['id']} ({s['visibility']})")
+
+    if args.dry_run:
+        print("\n--- generated .gitmodules ---")
+        print(content, end="")
+        return
+
+    out_path = Path(args.out)
+
+    if args.check:
+        existing = out_path.read_text(encoding="utf-8") if out_path.exists() else None
+        if existing != content:
+            print(f"\nDRIFT: {out_path} does not match generated output from {sources_path}",
+                  file=sys.stderr)
+            sys.exit(1)
+        print(f"\nOK: {out_path} matches {sources_path} (profile: {args.profile})")
+        return
+
+    out_path.write_text(content, encoding="utf-8")
+    print(f"\nWROTE: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_gitmodules.yaml
+++ b/tools/generate_gitmodules.yaml
@@ -1,0 +1,77 @@
+---
+module: tools.generate_gitmodules
+description: 'generate_gitmodules.py — Render .gitmodules from a declared knowledge.sources.yaml.
+  knowledge.sources.yaml is the declared desired state: which knowledge sources exist,
+  what role/visibility they have, and which build profile(s) include them. .gitmodules
+  is a generated Git-compatibility artifact — never hand-edited. Usage: python tools/generate_gitmodules.py
+  [--sources knowledge.sources.yaml] [--profile internal] [--out .gitmodules] [--check]
+  [--dry-run] Options: --sources   Path to the knowledge sources manifest (default:
+  knowledge.sources.yaml) --profile   Which profile''s includeVisibility to filter
+  by (default: internal) --out       Output .gitmodules path (default: .gitmodules)
+  --check     Don''t write; compare generated content against --out and exit non-zero
+  on drift (for CI) --dry-run   Print the generated content without writing it'
+tags:
+- builder
+- core
+- loader
+- validator
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: _REQUIRED_SOURCE_FIELDS
+  kind: const
+  description: ''
+  references: []
+- name: _GENERATED_HEADER
+  kind: const
+  description: ''
+  references: []
+- name: load_manifest
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - ValueError
+  - path.open
+  - yaml.safe_load
+- name: validate_manifest
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - ValueError
+  - data.get
+  - seen_ids.add
+  - source.get
+- name: select_sources
+  kind: function
+  decorators: []
+  description: Return (included, excluded) sources for the given profile.
+  references: []
+  calls:
+  - ValueError
+- name: render_gitmodules
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - _GENERATED_HEADER.format
+  - lines.append
+  - source.get
+- name: main
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - out_path.exists
+  - out_path.read_text
+  - out_path.write_text
+  - parser.add_argument
+  - parser.parse_args
+  - sources_path.exists

--- a/tools/git_hook_post-commit.sh
+++ b/tools/git_hook_post-commit.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# post-commit hook: auto-update companion YAMLs for changed Go files.
+#
+# Behaviour:
+#   - Runs go.meta.gen.py --merge only on Go files changed in the last commit.
+#   - Only updates companion YAMLs that already exist (never creates new ones).
+#   - Skips test files (*_test.go).
+#   - Silently exits if no Go files changed or no companion exists.
+#   - Does NOT auto-commit the updated companions (leave to the developer).
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TOOLS_DIR="$REPO_ROOT/tools"
+GEN_SCRIPT="$TOOLS_DIR/go.meta.gen.py"
+
+if [ ! -f "$GEN_SCRIPT" ]; then
+    exit 0
+fi
+
+# Find Python venv (prefer project venv, fall back to system python3)
+if [ -f "$REPO_ROOT/p_venv/bin/python" ]; then
+    PYTHON="$REPO_ROOT/p_venv/bin/python"
+elif [ -f "$REPO_ROOT/../MCPs/base/p_venv/bin/python" ]; then
+    PYTHON="$REPO_ROOT/../MCPs/base/p_venv/bin/python"
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON=python3
+else
+    exit 0
+fi
+
+# Get list of Go source files changed in the last commit (exclude test files)
+CHANGED_GO_FILES=$(git diff-tree --no-commit-id -r --name-only HEAD 2>/dev/null \
+    | grep '\.go$' \
+    | grep -v '_test\.go$' \
+    || true)
+
+if [ -z "$CHANGED_GO_FILES" ]; then
+    exit 0
+fi
+
+# Run --merge on each changed Go file that already has a companion YAML
+for GO_FILE in $CHANGED_GO_FILES; do
+    ABS_GO="$REPO_ROOT/$GO_FILE"
+    COMPANION="${ABS_GO%.go}.yaml"
+    if [ ! -f "$COMPANION" ]; then
+        continue
+    fi
+    "$PYTHON" "$GEN_SCRIPT" --file "$ABS_GO" --merge --quiet 2>/dev/null || true
+done
+
+exit 0

--- a/tools/go.meta.gen.py
+++ b/tools/go.meta.gen.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""go.meta.gen.py — Companion YAML skeleton generator for Go source files.
+
+Parses Go source files and generates a .yaml companion following go.meta.schema.yaml.
+Auto-filled fields:
+  - package, entrypoint
+  - objects: name, kind, receiver, references
+  - description: extracted from Go doc comments (// lines before declaration)
+  - tags: suggested from file path, imports, and naming conventions (review before use)
+
+Semantic fields left empty for human completion:
+  - category, used_in, related_nodes, implements
+
+Usage:
+    python tools/go.meta.gen.py <file.go> [<file.go> ...]
+    python tools/go.meta.gen.py --dir <directory> [--recursive] [--overwrite]
+
+Options:
+    --dir         Process all .go files in directory (default: non-recursive)
+    --recursive   Recurse into subdirectories (use with --dir)
+    --overwrite   Overwrite existing .yaml files (default: skip)
+    --skip-tests  Skip _test.go files (default: include)
+    --dry-run     Print what would be generated without writing files
+"""
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not found. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+# Allowed tag values from go.meta.schema.yaml — used to filter suggestions.
+_ALLOWED_TAGS = {
+    "relay", "compliance", "workflow", "cictor", "schema", "parser", "guard",
+    "core", "doc", "interface", "gateway", "builder", "test", "meta",
+    "orchestrator", "decision", "reflector", "context", "validator", "executor",
+    "hook", "template", "fallback", "session", "metrics", "storage", "loader",
+    "renderer", "legal", "license", "platform-engineering", "ci-cd", "ecosystem",
+}
+
+# Known first path segments of Go standard library packages.
+# Used to filter out stdlib imports when deciding if a reference is external.
+# Detection is path-based (not alias-based) to avoid false positives from
+# project-internal packages that happen to use common alias names like "types".
+_STDLIB_ROOTS = {
+    # single-segment stdlib
+    "builtin", "unsafe",
+    # multi-segment stdlib roots (first path component)
+    "archive", "bufio", "bytes", "compress", "container", "context",
+    "crypto", "database", "debug", "embed", "encoding", "errors", "expvar",
+    "flag", "fmt", "go", "hash", "html", "image", "io", "log", "math",
+    "mime", "net", "os", "path", "plugin", "reflect", "regexp", "runtime",
+    "sort", "strconv", "strings", "sync", "syscall", "testing", "text",
+    "time", "unicode", "unique", "slices", "maps", "cmp",
+}
+
+
+# ---------------------------------------------------------------------------
+# Source cleaning
+# ---------------------------------------------------------------------------
+
+def _remove_comments(source: str) -> str:
+    """Remove // and /* */ comments."""
+    source = re.sub(r'/\*.*?\*/', '', source, flags=re.DOTALL)
+    source = re.sub(r'//[^\n]*', '', source)
+    return source
+
+
+def _remove_strings(source: str) -> str:
+    """Replace string/rune literals with placeholders to avoid false matches.
+    Must be called after comment removal so apostrophes in comments don't confuse
+    the rune literal pattern."""
+    # Raw strings: `...`
+    source = re.sub(r'`[^`]*`', '``', source, flags=re.DOTALL)
+    # Interpreted strings: "..."
+    source = re.sub(r'"(?:[^"\\]|\\.)*"', '""', source)
+    # Rune literals: 'x' '\n' '\u0041' — max ~6 chars, never multiline
+    source = re.sub(r"'(?:[^'\\]|\\.){1,6}'", "''", source)
+    return source
+
+
+def _clean(source: str) -> str:
+    # Comments first — prevents apostrophes in comments from poisoning rune literal regex
+    return _remove_strings(_remove_comments(source))
+
+
+# ---------------------------------------------------------------------------
+# Block extraction (brace-matching)
+# ---------------------------------------------------------------------------
+
+def _extract_block_content(source: str, open_pos: int) -> str:
+    """Return content between matching { } starting at open_pos (the '{')."""
+    depth = 0
+    content = []
+    for i in range(open_pos, len(source)):
+        c = source[i]
+        if c == '{':
+            depth += 1
+        elif c == '}':
+            depth -= 1
+            if depth == 0:
+                break
+        elif depth > 0:
+            content.append(c)
+    return ''.join(content)
+
+
+# ---------------------------------------------------------------------------
+# Import parsing
+# ---------------------------------------------------------------------------
+
+def _parse_imports(source: str) -> dict[str, str]:
+    """Return {local_alias: import_path} for all imports in source.
+    Parses comment-stripped source so inline comments don't interfere,
+    but keeps string contents so import paths remain readable."""
+    imports: dict[str, str] = {}
+    no_comments = _remove_comments(source)  # keep strings intact
+
+    # Single: import "path"  or  import alias "path"
+    for m in re.finditer(r'^\s*import\s+(?:(\w+)\s+)?"([^"]+)"', no_comments, re.MULTILINE):
+        alias = m.group(1) or m.group(2).split('/')[-1]
+        imports[alias] = m.group(2)
+
+    # Block: import ( ... )
+    block_m = re.search(r'\bimport\s*\(([^)]+)\)', no_comments, re.DOTALL)
+    if block_m:
+        for line in block_m.group(1).splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            # alias "path"
+            m = re.match(r'(\w+|_|\.)\s+"([^"]+)"', line)
+            if m:
+                alias = m.group(1) if m.group(1) not in ('_', '.') else m.group(2).split('/')[-1]
+                imports[alias] = m.group(2)
+                continue
+            # "path"
+            m = re.match(r'"([^"]+)"', line)
+            if m:
+                alias = m.group(1).split('/')[-1]
+                imports[alias] = m.group(1)
+
+    return imports
+
+
+def _find_module_name(go_file: Path) -> str:
+    """Walk up from go_file to find go.mod and return the module name."""
+    for parent in go_file.parents:
+        mod = parent / "go.mod"
+        if mod.exists():
+            for line in mod.read_text().splitlines():
+                m = re.match(r'^\s*module\s+(\S+)', line)
+                if m:
+                    return m.group(1)
+    return ""
+
+
+def _is_stdlib_path(path: str) -> bool:
+    """True if the import path is a Go standard library package.
+    Stdlib paths have no dots and their first segment is a known stdlib root."""
+    if '.' in path:
+        return False  # third-party always has dots (github.com, gopkg.in, etc.)
+    return path.split('/')[0] in _STDLIB_ROOTS
+
+
+def _is_external(pkg: str, imports: dict[str, str], module_name: str = "") -> bool:
+    """True if pkg refers to a non-stdlib import.
+    Includes both third-party (github.com/...) and same-module cross-package refs
+    (e.g. centralrelay/core/cabinet). Only pure stdlib is excluded."""
+    if pkg not in imports:
+        return False
+    return not _is_stdlib_path(imports[pkg])
+
+
+def _extract_local_typed_vars(text: str, imports: dict[str, str], module_name: str = "") -> dict[str, str]:
+    """Return {var_name: pkg_alias} for explicitly typed local variable declarations.
+
+    Recognises these Go patterns:
+        var db *sql.DB          -> {"db": "sql"}
+        var c http.Client       -> {"c": "http"}
+        var r []types.Relay     -> {"r": "types"}
+
+    Only variables whose type package is a non-stdlib import are included.
+    Short declarations (:=) are intentionally not handled — too fragile without AST.
+    """
+    result: dict[str, str] = {}
+    # var <name> [*[]][<pkg>.<Type>]
+    pattern = re.compile(r'\bvar\s+(\w+)\s+(?:\[\]|\*)*(\w+)\.([A-Z]\w*)')
+    for m in pattern.finditer(text):
+        var_name, pkg = m.group(1), m.group(2)
+        if _is_external(pkg, imports, module_name):
+            result[var_name] = pkg
+    return result
+
+
+def _extract_refs(text: str, imports: dict[str, str], module_name: str = "") -> list[str]:
+    """Find non-stdlib pkg.Name references in text.
+
+    Two passes:
+    1. Direct package references: pkg.ExportedName  (types, funcs, consts)
+    2. Typed variable method calls: var db *sql.DB → db.QueryRow → sql.QueryRow
+    """
+    seen: dict[str, None] = {}  # ordered set preserving insertion order
+
+    # Pass 1 — direct: json.Marshal, relay.Actor, http.NewRequest, ...
+    for m in re.finditer(r'\b(\w+)\.([A-Z]\w*)', text):
+        pkg, name = m.group(1), m.group(2)
+        if _is_external(pkg, imports, module_name):
+            seen[f"{pkg}.{name}"] = None
+
+    # Pass 2 — typed variable methods: var db *sql.DB → db.QueryRow()
+    local_vars = _extract_local_typed_vars(text, imports, module_name)
+    for m in re.finditer(r'\b(\w+)\.([A-Z]\w*)\s*\(', text):
+        var_name, method = m.group(1), m.group(2)
+        pkg = local_vars.get(var_name)
+        if pkg:
+            seen[f"{pkg}.{method}"] = None
+
+    return list(seen)
+
+
+# ---------------------------------------------------------------------------
+# Doc comment extraction
+# ---------------------------------------------------------------------------
+
+def _extract_doc_comments(source: str) -> dict[str, str]:
+    """Extract Go doc comments for top-level declarations.
+
+    Matches contiguous `//` comment lines immediately preceding a declaration
+    and returns {identifier_name: comment_text}.
+
+    Examples:
+        // config holds the application configuration.
+        type config struct { ... }
+        -> {"config": "config holds the application configuration."}
+
+        // NewLoader creates a new Loader instance.
+        func NewLoader(source IaCSource) *Loader {
+        -> {"NewLoader": "NewLoader creates a new Loader instance."}
+    """
+    result: dict[str, str] = {}
+    pattern = re.compile(
+        r'((?:^[ \t]*//[^\n]*\n)+)'        # group 1: contiguous doc comment lines
+        r'[ \t]*(?:type|func|var|const)\s+'  # declaration keyword
+        r'(?:\([^)]*\)\s*)?'                 # optional method receiver
+        r'(\w+)',                            # group 2: identifier name
+        re.MULTILINE,
+    )
+    for m in pattern.finditer(source):
+        comment_block = m.group(1)
+        name = m.group(2)
+        lines = []
+        for line in comment_block.splitlines():
+            cleaned = re.sub(r'^\s*//\s?', '', line).strip()
+            if cleaned:
+                lines.append(cleaned)
+        if lines:
+            result[name] = ' '.join(lines)
+    return result
+
+
+def _extract_package_doc(source: str) -> str:
+    """Extract the package-level doc comment (// lines before 'package NAME')."""
+    m = re.search(r'((?:^[ \t]*//[^\n]*\n)+)[ \t]*package\s+\w+', source, re.MULTILINE)
+    if not m:
+        return ""
+    lines = []
+    for line in m.group(1).splitlines():
+        cleaned = re.sub(r'^\s*//\s?', '', line).strip()
+        if cleaned:
+            lines.append(cleaned)
+    return ' '.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tag suggestion
+# ---------------------------------------------------------------------------
+
+def _suggest_tags(go_file: Path, imports: dict[str, str], objects: list[dict]) -> list[str]:
+    """Suggest tags from file path, imports, and object naming conventions.
+
+    Returns a sorted list of allowed tag values (see go.meta.schema.yaml).
+    These are suggestions — review and trim before committing the YAML.
+    """
+    tags: set[str] = set()
+    path_str = str(go_file).replace('\\', '/')
+    filename = go_file.name
+
+    # --- file path hints ---
+    if '/cmd/' in path_str or filename == 'main.go':
+        tags.update(['core', 'gateway'])
+    if '/tools/' in path_str:
+        tags.add('builder')
+    if filename.endswith('_test.go'):
+        tags.add('test')
+    if '/core/' in path_str:
+        tags.add('core')
+
+    # --- import hints ---
+    import_paths = set(imports.values())
+    if any('net/http' in p for p in import_paths):
+        tags.add('interface')
+    if any('database/sql' in p or p.endswith('/sql') for p in import_paths):
+        tags.add('storage')
+    if any(p == 'testing' for p in import_paths):
+        tags.add('test')
+    if any('metric' in p.lower() or 'prometheus' in p.lower() for p in import_paths):
+        tags.add('metrics')
+
+    # --- object naming convention hints ---
+    for obj in objects:
+        name = obj['name']
+        if re.match(r'^Validate', name):
+            tags.add('validator')
+        if re.match(r'^Execute', name):
+            tags.add('executor')
+        if re.match(r'^Load', name):
+            tags.add('loader')
+        if re.search(r'Handler$', name):
+            tags.add('interface')
+        if re.search(r'Server$', name):
+            tags.add('interface')
+        if re.search(r'Store$|Repository$', name):
+            tags.add('storage')
+        if re.search(r'[Mm]etric', name):
+            tags.add('metrics')
+        if re.search(r'[Ss]chema', name):
+            tags.add('schema')
+        if re.match(r'^Parse|^Parser', name) or name.endswith('Parser'):
+            tags.add('parser')
+        if re.match(r'^Hook', name) or name.endswith('Hook'):
+            tags.add('hook')
+
+    # filter to allowed values only
+    return sorted(tags & _ALLOWED_TAGS)
+
+
+# ---------------------------------------------------------------------------
+# Object parsing
+# ---------------------------------------------------------------------------
+
+def _parse_objects(source: str, imports: dict[str, str], module_name: str = "") -> list[dict]:
+    objects: list[dict] = []
+    clean = _clean(source)
+    doc = _extract_doc_comments(source)
+
+    # --- structs ---
+    for m in re.finditer(r'\btype\s+(\w+)\s+struct\s*\{', clean):
+        name = m.group(1)
+        body = _extract_block_content(clean, m.end() - 1)
+        refs = _extract_refs(body, imports, module_name)
+        obj: dict = {"name": name, "kind": "struct",
+                     "description": doc.get(name, ""),
+                     "implements": [], "references": refs}
+        objects.append(obj)
+
+    struct_names = {o["name"] for o in objects}
+
+    # --- interfaces ---
+    for m in re.finditer(r'\btype\s+(\w+)\s+interface\s*\{', clean):
+        name = m.group(1)
+        body = _extract_block_content(clean, m.end() - 1)
+        refs = _extract_refs(body, imports, module_name)
+        objects.append({"name": name, "kind": "interface",
+                        "description": doc.get(name, ""), "references": refs})
+
+    iface_names = {o["name"] for o in objects if o["kind"] == "interface"}
+
+    # --- type aliases (not struct/interface) ---
+    for m in re.finditer(r'\btype\s+(\w+)\s+(?!struct\b|interface\b)(\S+)', clean, re.MULTILINE):
+        name = m.group(1)
+        if name in struct_names or name in iface_names:
+            continue
+        underlying = m.group(2)
+        refs = _extract_refs(underlying, imports, module_name)
+        objects.append({"name": name, "kind": "type",
+                        "description": doc.get(name, ""), "references": refs})
+
+    # --- funcs and methods ---
+    func_re = re.compile(
+        r'\bfunc\s+'
+        r'(?:\(\s*\w+\s+\*?(\w+)\s*\)\s*)?'   # group 1: receiver type (optional)
+        r'(\w+)\s*'                              # group 2: func name
+        r'\(([^)]*(?:\([^)]*\)[^)]*)*)\)'       # group 3: params
+        r'([^{]*)',                              # group 4: return types
+        re.MULTILINE,
+    )
+    for m in func_re.finditer(clean):
+        recv_type = m.group(1)
+        func_name = m.group(2)
+        params = m.group(3) or ''
+        returns = m.group(4) or ''
+        brace_pos = clean.find('{', m.end())
+        body = _extract_block_content(clean, brace_pos) if brace_pos != -1 else ''
+        refs = _extract_refs(f"{params} {returns} {body}", imports, module_name)
+
+        if recv_type:
+            objects.append({
+                "name": func_name,
+                "kind": "method",
+                "receiver": recv_type,
+                "description": doc.get(func_name, ""),
+                "references": refs,
+            })
+        else:
+            objects.append({
+                "name": func_name,
+                "kind": "func",
+                "description": doc.get(func_name, ""),
+                "references": refs,
+            })
+
+    # --- package-level vars ---
+    for m in re.finditer(r'^var\s+(\w+)', clean, re.MULTILINE):
+        name = m.group(1)
+        objects.append({"name": name, "kind": "var",
+                        "description": doc.get(name, ""), "references": []})
+
+    # --- package-level consts ---
+    for m in re.finditer(r'^const\s+(\w+)\b', clean, re.MULTILINE):
+        name = m.group(1)
+        objects.append({"name": name, "kind": "const",
+                        "description": doc.get(name, ""), "references": []})
+
+    return objects
+
+
+# ---------------------------------------------------------------------------
+# Main generator
+# ---------------------------------------------------------------------------
+
+def generate(go_file: Path) -> dict:
+    source = go_file.read_text(encoding="utf-8")
+
+    pkg_m = re.search(r'^\s*package\s+(\w+)', source, re.MULTILINE)
+    package = pkg_m.group(1) if pkg_m else ""
+
+    module_name = _find_module_name(go_file)
+    imports = _parse_imports(source)
+    objects = _parse_objects(source, imports, module_name)
+
+    return {
+        "package": package,
+        "description": _extract_package_doc(source),
+        "tags": _suggest_tags(go_file, imports, objects),
+        "category": [],
+        "used_in": [],
+        "entrypoint": package == "main",
+        "related_nodes": [],
+        "objects": objects,
+    }
+
+
+def _merge_data(new_data: dict, old_data: dict) -> dict:
+    """Merge freshly generated data into an existing YAML.
+
+    Auto fields (always updated from source):
+      package, entrypoint, objects.references, objects.kind, objects.receiver
+
+    Description fields (updated only if doc comment exists in source):
+      description (file-level), objects[].description
+      If the new description is empty, the existing value is preserved.
+
+    Manual fields (never touched):
+      tags, category, used_in, related_nodes, objects[].implements
+
+    Objects:
+      - New objects (added to Go source) → appended
+      - Removed objects (deleted from Go source) → dropped
+      - Existing objects → merged per field rules above
+    """
+    merged = dict(new_data)
+
+    # preserve all manual top-level fields
+    merged['tags'] = old_data.get('tags', new_data.get('tags', []))
+    merged['category'] = old_data.get('category', [])
+    merged['used_in'] = old_data.get('used_in', [])
+    merged['related_nodes'] = old_data.get('related_nodes', [])
+
+    # description: keep new if non-empty (from doc comment), else preserve old
+    if not merged.get('description'):
+        merged['description'] = old_data.get('description', '')
+
+    # merge objects by name
+    old_by_name: dict[str, dict] = {o['name']: o for o in old_data.get('objects', [])}
+    merged_objects = []
+    for new_obj in new_data.get('objects', []):
+        name = new_obj['name']
+        if name in old_by_name:
+            old_obj = old_by_name[name]
+            obj = dict(new_obj)                          # structural fields from new
+            if obj.get('kind') == 'struct':              # implements only meaningful on structs
+                obj['implements'] = old_obj.get('implements', [])
+            if not obj.get('description'):               # keep manual description if no doc comment
+                obj['description'] = old_obj.get('description', '')
+        else:
+            obj = new_obj                                # new object — use as-is
+        merged_objects.append(obj)
+
+    merged['objects'] = merged_objects
+    return merged
+
+
+def _write_yaml(data: dict, path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---\n")
+        yaml.dump(data, f, allow_unicode=True, default_flow_style=False,
+                  sort_keys=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate companion YAML skeletons for Go source files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("files", nargs="*", metavar="FILE",
+                        help="Go source files to process")
+    parser.add_argument("--dir", metavar="DIR",
+                        help="Process all .go files in DIR")
+    parser.add_argument("--recursive", action="store_true",
+                        help="Recurse into subdirectories (use with --dir)")
+    parser.add_argument("--overwrite", action="store_true",
+                        help="Overwrite existing YAML files completely")
+    parser.add_argument("--merge", action="store_true",
+                        help="Update auto fields (references, descriptions from doc comments) "
+                             "while preserving manual fields (tags, category, used_in, "
+                             "related_nodes, implements). Implies --overwrite for existing files.")
+    parser.add_argument("--skip-tests", action="store_true",
+                        help="Skip _test.go files")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print actions without writing files")
+    args = parser.parse_args()
+
+    files: list[Path] = [Path(f) for f in args.files]
+    if args.dir:
+        d = Path(args.dir)
+        glob = d.rglob("*.go") if args.recursive else d.glob("*.go")
+        files += list(glob)
+
+    if not files:
+        parser.print_help()
+        sys.exit(1)
+
+    generated = merged_count = skipped = errors = 0
+    for go_file in sorted(set(files)):
+        if not go_file.exists():
+            print(f"NOT FOUND: {go_file}", file=sys.stderr)
+            errors += 1
+            continue
+        if args.skip_tests and go_file.name.endswith("_test.go"):
+            continue
+
+        yaml_file = go_file.with_suffix(".yaml")
+        existing = yaml_file.exists()
+
+        if existing and not args.overwrite and not args.merge:
+            print(f"SKIP (exists): {yaml_file}")
+            skipped += 1
+            continue
+
+        try:
+            data = generate(go_file)
+        except Exception as e:
+            print(f"ERROR: {go_file}: {e}", file=sys.stderr)
+            errors += 1
+            continue
+
+        if existing and args.merge:
+            try:
+                with open(yaml_file) as f:
+                    old_data = yaml.safe_load(f) or {}
+                data = _merge_data(data, old_data)
+                action = "MERGED"
+                merged_count += 1
+            except Exception as e:
+                print(f"ERROR reading existing {yaml_file}: {e}", file=sys.stderr)
+                errors += 1
+                continue
+        else:
+            action = "GENERATED"
+            generated += 1
+
+        obj_count = len(data["objects"])
+        ref_count = sum(len(o.get("references", [])) for o in data["objects"])
+
+        if args.dry_run:
+            print(f"DRY-RUN ({action}): {yaml_file}  [{obj_count} objects, {ref_count} refs]")
+        else:
+            _write_yaml(data, yaml_file)
+            print(f"{action}: {yaml_file}  [{obj_count} objects, {ref_count} refs]")
+
+    summary = f"\nDone: {generated} generated, {merged_count} merged, {skipped} skipped, {errors} errors"
+    print(summary)
+    if errors:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/go.meta.gen.py
+++ b/tools/go.meta.gen.py
@@ -177,6 +177,14 @@ def _is_external(pkg: str, imports: dict[str, str], module_name: str = "") -> bo
     return not _is_stdlib_path(imports[pkg])
 
 
+def _extract_interface_methods(body: str) -> list[str]:
+    """Extract exported method names from an interface body."""
+    methods = []
+    for m in re.finditer(r'^\s+([A-Z]\w*)\s*\(', body, re.MULTILINE):
+        methods.append(m.group(1))
+    return sorted(set(methods))
+
+
 def _extract_calls(body: str, refs: list[str] | None = None) -> list[str]:
     """Extract function/method calls from function body with type resolution.
 
@@ -480,8 +488,10 @@ def _parse_objects(source: str, imports: dict[str, str], module_name: str = "") 
         name = m.group(1)
         body = _extract_block_content(clean, m.end() - 1)
         refs = _extract_refs(body, imports, module_name)
+        methods = _extract_interface_methods(body)
         objects.append({"name": name, "kind": "interface",
-                        "description": doc.get(name, ""), "references": refs})
+                        "description": doc.get(name, ""), "references": refs,
+                        "methods": methods})
 
     iface_names = {o["name"] for o in objects if o["kind"] == "interface"}
 
@@ -582,6 +592,48 @@ def generate(go_file: Path) -> dict:
     }
 
 
+def _detect_implements(yaml_dir: Path) -> dict[str, list[str]]:
+    """Scan all YAML files in yaml_dir and return {struct_name: [interface_names]}
+    based on method-set inclusion.
+
+    A struct S implements interface I if all exported methods of I appear as
+    kind=method objects with receiver=S across any YAML in the directory.
+
+    Returns a dict mapping struct names to the list of interfaces they implement.
+    Does NOT modify any files — callers are responsible for applying results.
+    """
+    ifaces: dict[str, set[str]] = {}   # {iface_name: {method_name, ...}}
+    struct_methods: dict[str, set[str]] = {}  # {struct_name: {method_name, ...}}
+
+    for yaml_file in sorted(yaml_dir.glob("*.yaml")):
+        try:
+            with open(yaml_file) as f:
+                data = yaml.safe_load(f) or {}
+        except Exception:
+            continue
+        for obj in data.get("objects", []):
+            kind = obj.get("kind")
+            name = obj.get("name", "")
+            if kind == "interface":
+                methods = obj.get("methods", [])
+                if methods:
+                    ifaces[name] = set(methods)
+            elif kind == "method":
+                receiver = obj.get("receiver", "")
+                if receiver:
+                    struct_methods.setdefault(receiver, set()).add(name)
+
+    result: dict[str, list[str]] = {}
+    for struct, methods in struct_methods.items():
+        impls = []
+        for iface, iface_methods in ifaces.items():
+            if iface_methods and iface_methods.issubset(methods):
+                impls.append(iface)
+        if impls:
+            result[struct] = sorted(impls)
+    return result
+
+
 def _merge_data(new_data: dict, old_data: dict) -> dict:
     """Merge freshly generated data into an existing YAML.
 
@@ -661,9 +713,14 @@ def main() -> None:
                         help="Skip _test.go files")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print actions without writing files")
+    parser.add_argument("--detect-implements", action="store_true",
+                        help="After generating/merging, detect interface implementations "
+                             "by method-set inclusion across all YAMLs in the same directory "
+                             "and fill in the implements field. Only effective with --dir.")
     args = parser.parse_args()
 
     files: list[Path] = [Path(f) for f in args.files]
+    dirs_processed: set[Path] = set()
     if args.dir:
         d = Path(args.dir)
         glob = d.rglob("*.go") if args.recursive else d.glob("*.go")
@@ -720,9 +777,37 @@ def main() -> None:
         else:
             _write_yaml(data, yaml_file)
             print(f"{action}: {yaml_file}  [{obj_count} objects, {ref_count} refs]")
+            dirs_processed.add(go_file.parent)
 
     summary = f"\nDone: {generated} generated, {merged_count} merged, {skipped} skipped, {errors} errors"
     print(summary)
+
+    # Interface implementation detection pass
+    if args.detect_implements and not args.dry_run and dirs_processed:
+        impl_count = 0
+        for yaml_dir in sorted(dirs_processed):
+            impl_map = _detect_implements(yaml_dir)
+            if not impl_map:
+                continue
+            for yaml_file in sorted(yaml_dir.glob("*.yaml")):
+                try:
+                    with open(yaml_file) as f:
+                        data = yaml.safe_load(f) or {}
+                except Exception:
+                    continue
+                changed = False
+                for obj in data.get("objects", []):
+                    if obj.get("kind") == "struct":
+                        impls = impl_map.get(obj["name"], [])
+                        if impls and obj.get("implements") != impls:
+                            obj["implements"] = impls
+                            changed = True
+                            impl_count += 1
+                if changed:
+                    _write_yaml(data, yaml_file)
+                    print(f"IMPLEMENTS: {yaml_file.name} — updated {sum(1 for o in data['objects'] if o.get('kind')=='struct' and o.get('implements'))} structs")
+        print(f"Interface detection: {impl_count} struct(s) updated with implements")
+
     if errors:
         sys.exit(1)
 

--- a/tools/go.meta.gen.py
+++ b/tools/go.meta.gen.py
@@ -177,6 +177,95 @@ def _is_external(pkg: str, imports: dict[str, str], module_name: str = "") -> bo
     return not _is_stdlib_path(imports[pkg])
 
 
+def _extract_calls(body: str, refs: list[str] | None = None) -> list[str]:
+    """Extract function/method calls from function body with type resolution.
+
+    First extracts method names from body (Set, Query, etc).
+    Then resolves types using references (cabinet.Cabinet.Set, sql.DB.Query, etc).
+
+    Examples:
+        body: "s.Set(db.Query())"  refs: ["cabinet.Cabinet.Set", "sql.DB.Query"]
+        → ["cabinet.Cabinet.Set", "sql.DB.Query"]
+
+    Falls back to untyped calls if refs unavailable:
+        body: "s.Set(db.Query())"  refs: None
+        → ["Set", "Query"]
+    """
+    calls = []
+    call_names = set()
+
+    # Extract bare method/function names
+    # First pattern: pkg.Name()
+    for m in re.finditer(r'\b\w+\.([A-Z]\w*)\s*\(', body):
+        call_names.add(m.group(1))
+
+    # Second pattern: standalone Name()
+    for m in re.finditer(r'\b([A-Z]\w*)\s*\(', body):
+        call_names.add(m.group(1))
+
+    # Type resolution: match call names against references
+    if refs:
+        typed_calls = []
+        for ref in refs:
+            # ref format: "cabinet.Cabinet.Set", extract the method name
+            method_name = ref.split('.')[-1]  # "Set" from "cabinet.Cabinet.Set"
+            if method_name in call_names:
+                typed_calls.append(ref)
+
+        # Return typed calls if found, otherwise fall back to bare names
+        if typed_calls:
+            return sorted(set(typed_calls))
+
+    # Fallback: return untyped call names
+    return sorted(call_names) if call_names else []
+
+
+def _extract_param_types(params_str: str, imports: dict[str, str], module_name: str = "") -> dict[str, str]:
+    """Extract {param_name: pkg_alias} from function parameter list.
+
+    Examples:
+        "s *Service, db *sql.DB" -> {"s": "Service", "db": "sql"}
+        "ops nexusgit.GitOps" -> {"ops": "nexusgit.GitOps"}
+    """
+    result: dict[str, str] = {}
+    if not params_str:
+        return result
+
+    # Split by comma, but handle nested parens (e.g., func types)
+    parts = []
+    current = []
+    depth = 0
+    for c in params_str:
+        if c == '(':
+            depth += 1
+        elif c == ')':
+            depth -= 1
+        elif c == ',' and depth == 0:
+            parts.append(''.join(current).strip())
+            current = []
+            continue
+        current.append(c)
+    if current:
+        parts.append(''.join(current).strip())
+
+    # Parse each parameter: [*]pkg.Type or [*]Type
+    for part in parts:
+        if not part or part.startswith('...'):
+            continue
+
+        # Extract type: skip pointer, handle []
+        type_part = re.sub(r'^[\[\]*]+', '', part).strip()
+
+        # Extract param name: "s *Service" → name="s", type="Service"
+        m = re.match(r'^(\w+)\s+([\w.]+)$', type_part)
+        if m:
+            param_name = m.group(1)
+            param_type = m.group(2)
+            result[param_name] = param_type
+
+    return result
+
+
 def _extract_local_typed_vars(text: str, imports: dict[str, str], module_name: str = "") -> dict[str, str]:
     """Return {var_name: pkg_alias} for explicitly typed local variable declarations.
 
@@ -198,12 +287,16 @@ def _extract_local_typed_vars(text: str, imports: dict[str, str], module_name: s
     return result
 
 
-def _extract_refs(text: str, imports: dict[str, str], module_name: str = "") -> list[str]:
+def _extract_refs(text: str, imports: dict[str, str], module_name: str = "",
+                   param_types: dict[str, str] | None = None,
+                   receiver_type: str | None = None,
+                   receiver_name: str = 's') -> list[str]:
     """Find non-stdlib pkg.Name references in text.
 
-    Two passes:
+    Three passes:
     1. Direct package references: pkg.ExportedName  (types, funcs, consts)
     2. Typed variable method calls: var db *sql.DB → db.QueryRow → sql.QueryRow
+    3. Parameter/receiver method calls: func f(s *Service) { s.Method() } → Service.Method
     """
     seen: dict[str, None] = {}  # ordered set preserving insertion order
 
@@ -220,6 +313,25 @@ def _extract_refs(text: str, imports: dict[str, str], module_name: str = "") -> 
         pkg = local_vars.get(var_name)
         if pkg:
             seen[f"{pkg}.{method}"] = None
+
+    # Pass 3 — parameter/receiver method calls
+    # param_types: {"s": "Service", "ops": "nexusgit.GitOps"}
+    # receiver_type: "Service" (for methods), receiver_name: "s"
+    if param_types:
+        local_vars.update(param_types)
+    if receiver_type:
+        local_vars[receiver_name] = receiver_type  # implicit receiver, e.g., s *relayServer → s: relayServer
+
+    for m in re.finditer(r'\b(\w+)\.([A-Z]\w*)\s*\(', text):
+        var_name, method = m.group(1), m.group(2)
+        type_name = local_vars.get(var_name)
+        if type_name and '.' in type_name:
+            # Already has package: "nexusgit.GitOps"
+            seen[f"{type_name}.{method}"] = None
+        elif type_name and _is_external(type_name, imports, module_name):
+            # Type is a local package: "Service" → resolve via imports
+            # This would need symbol table, skip for now
+            pass
 
     return list(seen)
 
@@ -353,6 +465,8 @@ def _parse_objects(source: str, imports: dict[str, str], module_name: str = "") 
     for m in re.finditer(r'\btype\s+(\w+)\s+struct\s*\{', clean):
         name = m.group(1)
         body = _extract_block_content(clean, m.end() - 1)
+        # Struct fields could have types, but they're just declarations
+        # Extract refs from field types
         refs = _extract_refs(body, imports, module_name)
         obj: dict = {"name": name, "kind": "struct",
                      "description": doc.get(name, ""),
@@ -384,20 +498,30 @@ def _parse_objects(source: str, imports: dict[str, str], module_name: str = "") 
     # --- funcs and methods ---
     func_re = re.compile(
         r'\bfunc\s+'
-        r'(?:\(\s*\w+\s+\*?(\w+)\s*\)\s*)?'   # group 1: receiver type (optional)
-        r'(\w+)\s*'                              # group 2: func name
-        r'\(([^)]*(?:\([^)]*\)[^)]*)*)\)'       # group 3: params
-        r'([^{]*)',                              # group 4: return types
+        r'(?:\(\s*(\w+)\s+\*?(\w+)\s*\)\s*)?'   # group 1: receiver name, group 2: receiver type (optional)
+        r'(\w+)\s*'                               # group 3: func name
+        r'\(([^)]*(?:\([^)]*\)[^)]*)*)\)'        # group 4: params
+        r'([^{]*)',                               # group 5: return types
         re.MULTILINE,
     )
     for m in func_re.finditer(clean):
-        recv_type = m.group(1)
-        func_name = m.group(2)
-        params = m.group(3) or ''
-        returns = m.group(4) or ''
+        recv_name = m.group(1)
+        recv_type = m.group(2)
+        func_name = m.group(3)
+        params = m.group(4) or ''
+        returns = m.group(5) or ''
         brace_pos = clean.find('{', m.end())
         body = _extract_block_content(clean, brace_pos) if brace_pos != -1 else ''
-        refs = _extract_refs(f"{params} {returns} {body}", imports, module_name)
+
+        # Extract parameter types and pass to _extract_refs
+        param_types = _extract_param_types(params, imports, module_name)
+        refs = _extract_refs(f"{params} {returns} {body}", imports, module_name,
+                            param_types=param_types, receiver_type=recv_type,
+                            receiver_name=recv_name or 's')
+
+        # Extract function/method calls from body with type resolution
+        # Pass refs for type resolution: match call names against full refs
+        calls = _extract_calls(body, refs)
 
         if recv_type:
             objects.append({
@@ -406,6 +530,7 @@ def _parse_objects(source: str, imports: dict[str, str], module_name: str = "") 
                 "receiver": recv_type,
                 "description": doc.get(func_name, ""),
                 "references": refs,
+                "calls": calls,
             })
         else:
             objects.append({
@@ -413,6 +538,7 @@ def _parse_objects(source: str, imports: dict[str, str], module_name: str = "") 
                 "kind": "func",
                 "description": doc.get(func_name, ""),
                 "references": refs,
+                "calls": calls,
             })
 
     # --- package-level vars ---

--- a/tools/go.meta.gen.yaml
+++ b/tools/go.meta.gen.yaml
@@ -1,0 +1,147 @@
+---
+module: tools.go.meta.gen
+description: 'go.meta.gen.py — Companion YAML skeleton generator for Go source files.
+  Parses Go source files and generates a .yaml companion following go.meta.schema.yaml.
+  Auto-filled fields: - package, entrypoint - objects: name, kind, receiver, references
+  - description: extracted from Go doc comments (// lines before declaration) - tags:
+  suggested from file path, imports, and naming conventions (review before use) Semantic
+  fields left empty for human completion: - category, used_in, related_nodes, implements
+  Usage: python tools/go.meta.gen.py <file.go> [<file.go> ...] python tools/go.meta.gen.py
+  --dir <directory> [--recursive] [--overwrite] Options: --dir         Process all
+  .go files in directory (default: non-recursive) --recursive   Recurse into subdirectories
+  (use with --dir) --overwrite   Overwrite existing .yaml files (default: skip) --skip-tests  Skip
+  _test.go files (default: include) --dry-run     Print what would be generated without
+  writing files'
+tags:
+- builder
+- core
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: _ALLOWED_TAGS
+  kind: const
+  description: ''
+  references: []
+- name: _STDLIB_ROOTS
+  kind: const
+  description: ''
+  references: []
+- name: _remove_comments
+  kind: function
+  decorators: []
+  description: Remove // and /* */ comments.
+  references: []
+- name: _remove_strings
+  kind: function
+  decorators: []
+  description: Replace string/rune literals with placeholders to avoid false matches.
+    Must be called after comment removal so apostrophes in comments don't confuse
+    the rune literal pattern.
+  references: []
+- name: _clean
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _extract_block_content
+  kind: function
+  decorators: []
+  description: Return content between matching { } starting at open_pos (the '{').
+  references: []
+- name: _parse_imports
+  kind: function
+  decorators: []
+  description: 'Return {local_alias: import_path} for all imports in source. Parses
+    comment-stripped source so inline comments don''t interfere, but keeps string
+    contents so import paths remain readable.'
+  references: []
+- name: _find_module_name
+  kind: function
+  decorators: []
+  description: Walk up from go_file to find go.mod and return the module name.
+  references: []
+- name: _is_stdlib_path
+  kind: function
+  decorators: []
+  description: True if the import path is a Go standard library package. Stdlib paths
+    have no dots and their first segment is a known stdlib root.
+  references: []
+- name: _is_external
+  kind: function
+  decorators: []
+  description: True if pkg refers to a non-stdlib import. Includes both third-party
+    (github.com/...) and same-module cross-package refs (e.g. centralrelay/core/cabinet).
+    Only pure stdlib is excluded.
+  references: []
+- name: _extract_local_typed_vars
+  kind: function
+  decorators: []
+  description: 'Return {var_name: pkg_alias} for explicitly typed local variable declarations.
+    Recognises these Go patterns: var db *sql.DB          -> {"db": "sql"} var c http.Client       ->
+    {"c": "http"} var r []types.Relay     -> {"r": "types"} Only variables whose type
+    package is a non-stdlib import are included. Short declarations (:=) are intentionally
+    not handled — too fragile without AST.'
+  references: []
+- name: _extract_refs
+  kind: function
+  decorators: []
+  description: 'Find non-stdlib pkg.Name references in text. Two passes: 1. Direct
+    package references: pkg.ExportedName  (types, funcs, consts) 2. Typed variable
+    method calls: var db *sql.DB → db.QueryRow → sql.QueryRow'
+  references: []
+- name: _extract_doc_comments
+  kind: function
+  decorators: []
+  description: 'Extract Go doc comments for top-level declarations. Matches contiguous
+    `//` comment lines immediately preceding a declaration and returns {identifier_name:
+    comment_text}. Examples: // config holds the application configuration. type config
+    struct { ... } -> {"config": "config holds the application configuration."} //
+    NewLoader creates a new Loader instance. func NewLoader(source IaCSource) *Loader
+    { -> {"NewLoader": "NewLoader creates a new Loader instance."}'
+  references: []
+- name: _extract_package_doc
+  kind: function
+  decorators: []
+  description: Extract the package-level doc comment (// lines before 'package NAME').
+  references: []
+- name: _suggest_tags
+  kind: function
+  decorators: []
+  description: Suggest tags from file path, imports, and object naming conventions.
+    Returns a sorted list of allowed tag values (see go.meta.schema.yaml). These are
+    suggestions — review and trim before committing the YAML.
+  references: []
+- name: _parse_objects
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: generate
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _merge_data
+  kind: function
+  decorators: []
+  description: 'Merge freshly generated data into an existing YAML. Auto fields (always
+    updated from source): package, entrypoint, objects.references, objects.kind, objects.receiver
+    Description fields (updated only if doc comment exists in source): description
+    (file-level), objects[].description If the new description is empty, the existing
+    value is preserved. Manual fields (never touched): tags, category, used_in, related_nodes,
+    objects[].implements Objects: - New objects (added to Go source) → appended -
+    Removed objects (deleted from Go source) → dropped - Existing objects → merged
+    per field rules above'
+  references: []
+- name: _write_yaml
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: main
+  kind: function
+  decorators: []
+  description: ''
+  references: []

--- a/tools/go.meta.gen.yaml
+++ b/tools/go.meta.gen.yaml
@@ -33,6 +33,7 @@ objects:
   decorators: []
   description: Remove // and /* */ comments.
   references: []
+  calls: []
 - name: _remove_strings
   kind: function
   decorators: []
@@ -40,16 +41,22 @@ objects:
     Must be called after comment removal so apostrophes in comments don't confuse
     the rune literal pattern.
   references: []
+  calls: []
 - name: _clean
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _remove_comments
+  - _remove_strings
 - name: _extract_block_content
   kind: function
   decorators: []
   description: Return content between matching { } starting at open_pos (the '{').
   references: []
+  calls:
+  - content.append
 - name: _parse_imports
   kind: function
   decorators: []
@@ -57,17 +64,28 @@ objects:
     comment-stripped source so inline comments don''t interfere, but keeps string
     contents so import paths remain readable.'
   references: []
+  calls:
+  - _remove_comments
+  - block_m.group
+  - line.strip
+  - m.group
 - name: _find_module_name
   kind: function
   decorators: []
   description: Walk up from go_file to find go.mod and return the module name.
   references: []
+  calls:
+  - m.group
+  - mod.exists
+  - mod.read_text
 - name: _is_stdlib_path
   kind: function
   decorators: []
   description: True if the import path is a Go standard library package. Stdlib paths
     have no dots and their first segment is a known stdlib root.
   references: []
+  calls:
+  - path.split
 - name: _is_external
   kind: function
   decorators: []
@@ -75,6 +93,35 @@ objects:
     (github.com/...) and same-module cross-package refs (e.g. centralrelay/core/cabinet).
     Only pure stdlib is excluded.
   references: []
+  calls:
+  - _is_stdlib_path
+- name: _extract_calls
+  kind: function
+  decorators: []
+  description: 'Extract function/method calls from function body with type resolution.
+    First extracts method names from body (Set, Query, etc). Then resolves types using
+    references (cabinet.Cabinet.Set, sql.DB.Query, etc). Examples: body: "s.Set(db.Query())"  refs:
+    ["cabinet.Cabinet.Set", "sql.DB.Query"] → ["cabinet.Cabinet.Set", "sql.DB.Query"]
+    Falls back to untyped calls if refs unavailable: body: "s.Set(db.Query())"  refs:
+    None → ["Set", "Query"]'
+  references: []
+  calls:
+  - call_names.add
+  - m.group
+  - ref.split
+  - typed_calls.append
+- name: _extract_param_types
+  kind: function
+  decorators: []
+  description: 'Extract {param_name: pkg_alias} from function parameter list. Examples:
+    "s *Service, db *sql.DB" -> {"s": "Service", "db": "sql"} "ops nexusgit.GitOps"
+    -> {"ops": "nexusgit.GitOps"}'
+  references: []
+  calls:
+  - current.append
+  - m.group
+  - part.startswith
+  - parts.append
 - name: _extract_local_typed_vars
   kind: function
   decorators: []
@@ -84,13 +131,24 @@ objects:
     package is a non-stdlib import are included. Short declarations (:=) are intentionally
     not handled — too fragile without AST.'
   references: []
+  calls:
+  - _is_external
+  - m.group
+  - pattern.finditer
 - name: _extract_refs
   kind: function
   decorators: []
-  description: 'Find non-stdlib pkg.Name references in text. Two passes: 1. Direct
+  description: 'Find non-stdlib pkg.Name references in text. Three passes: 1. Direct
     package references: pkg.ExportedName  (types, funcs, consts) 2. Typed variable
-    method calls: var db *sql.DB → db.QueryRow → sql.QueryRow'
+    method calls: var db *sql.DB → db.QueryRow → sql.QueryRow 3. Parameter/receiver
+    method calls: func f(s *Service) { s.Method() } → Service.Method'
   references: []
+  calls:
+  - _extract_local_typed_vars
+  - _is_external
+  - local_vars.get
+  - local_vars.update
+  - m.group
 - name: _extract_doc_comments
   kind: function
   decorators: []
@@ -101,11 +159,19 @@ objects:
     NewLoader creates a new Loader instance. func NewLoader(source IaCSource) *Loader
     { -> {"NewLoader": "NewLoader creates a new Loader instance."}'
   references: []
+  calls:
+  - comment_block.splitlines
+  - lines.append
+  - m.group
+  - pattern.finditer
 - name: _extract_package_doc
   kind: function
   decorators: []
   description: Extract the package-level doc comment (// lines before 'package NAME').
   references: []
+  calls:
+  - lines.append
+  - m.group
 - name: _suggest_tags
   kind: function
   decorators: []
@@ -113,16 +179,45 @@ objects:
     Returns a sorted list of allowed tag values (see go.meta.schema.yaml). These are
     suggestions — review and trim before committing the YAML.
   references: []
+  calls:
+  - filename.endswith
+  - imports.values
+  - name.endswith
+  - p.endswith
+  - p.lower
+  - tags.add
+  - tags.update
 - name: _parse_objects
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _clean
+  - _extract_block_content
+  - _extract_calls
+  - _extract_doc_comments
+  - _extract_param_types
+  - _extract_refs
+  - clean.find
+  - doc.get
+  - func_re.finditer
+  - m.end
+  - m.group
+  - objects.append
 - name: generate
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _extract_package_doc
+  - _find_module_name
+  - _parse_imports
+  - _parse_objects
+  - _suggest_tags
+  - go_file.read_text
+  - pkg_m.group
 - name: _merge_data
   kind: function
   decorators: []
@@ -135,13 +230,36 @@ objects:
     Removed objects (deleted from Go source) → dropped - Existing objects → merged
     per field rules above'
   references: []
+  calls:
+  - merged.get
+  - merged_objects.append
+  - new_data.get
+  - obj.get
+  - old_data.get
+  - old_obj.get
 - name: _write_yaml
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - f.write
+  - yaml.dump
 - name: main
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _merge_data
+  - _write_yaml
+  - d.glob
+  - d.rglob
+  - go_file.exists
+  - go_file.with_suffix
+  - o.get
+  - parser.add_argument
+  - parser.parse_args
+  - parser.print_help
+  - yaml.safe_load
+  - yaml_file.exists

--- a/tools/infra.py
+++ b/tools/infra.py
@@ -1,14 +1,13 @@
 import base64
 import datetime
 import hashlib
-import json  # Added import for json
+import json
 import logging
 import os
-import sys
 import tempfile
 from pathlib import Path
 
-import requests  # Import requests for API accessibility check
+import requests
 import yaml
 from jsonschema import ValidationError as JsonSchemaValidationError
 from jsonschema import validate
@@ -23,7 +22,6 @@ from .releaselib.exceptions import (
 
 class ValidationFailureError(ReleaseError):
     """Custom exception for schema validation failures."""
-
     pass
 
 
@@ -99,46 +97,9 @@ class ReleaseManager:
     def _path(self, relative_path):
         return self.project_root / relative_path
 
-    def _check_base_branch_and_version(
-        self, release_version: str, skip_git_state_checks: bool = False
-    ):
-        """Checks git state, branch, and version validity."""
-        component_name = self.config.get("component_name", "main")
-        original_base_branch = self.git_service.get_current_branch()
-        self.logger.info(
-            f"✓ Starting release process for component '{component_name}' from branch '{original_base_branch}'."
-        )
-
-        if not skip_git_state_checks:
-            if self.git_service.is_dirty():
-                raise GitStateError(
-                    "Uncommitted changes detected. Please commit or stash them before starting a release."
-                )
-            self.git_service.assert_clean_index()
-
-        return component_name, original_base_branch
-
-    def _check_api_accessibility(self, api_url: str):
-        """
-        Checks if a given API URL is accessible.
-        Exits with 0 regardless of success/failure, as requested.
-        """
-        self.logger.info(f"Checking API accessibility for: {api_url}")
-        try:
-            response = requests.get(api_url, timeout=5)
-            response.raise_for_status()
-            self.logger.info(
-                f"✓ API '{api_url}' is accessible. Status: {response.status_code}"
-            )
-        except requests.exceptions.RequestException as e:
-            self.logger.warning(f"API '{api_url}' is NOT accessible: {e}")
-        # As requested, exit with 0 regardless of accessibility
-        sys.exit(0)
-
     def _validate_final_project_yaml(self):
         """
         Validates the project.yaml against the project.schema.yaml.
-        This is used in the finalization phase to ensure all required fields (including signatures) are present.
         """
         self.logger.info("Validating final project.yaml against schema...")
         try:
@@ -165,12 +126,53 @@ class ReleaseManager:
                 f"An unexpected error occurred during project.yaml validation: {e}"
             )
 
-    def _execute_developer_preparation_phase(
-        self, release_version: str, component_name: str, original_base_branch: str
-    ):
+    def run_check(self, release_version: str):
         """
-        Handles the developer preparation phase: creates release branch, updates project.yaml, commits, tags.
+        Performs pre-flight checks for a release.
         """
+        self.logger.info(f"--- Running Pre-flight Checks for v{release_version} ---")
+
+        if not self.vault_service:
+            raise VaultServiceError("VaultService is not initialized.")
+
+        if self.git_service.is_dirty():
+            raise GitStateError(
+                "Uncommitted changes detected. Please commit or stash them before starting a release."
+            )
+        self.git_service.assert_clean_index()
+        self.logger.info("✓ Git repository is clean.")
+
+        # Check Vault connectivity
+        try:
+            self.vault_service.check_connection()
+            self.logger.info("✓ Vault connection successful.")
+        except VaultServiceError as e:
+            raise VaultServiceError(f"Vault connection check failed: {e}") from e
+
+        self.logger.info("✓ Pre-flight checks passed.")
+        return True
+
+    def run_prepare_release(self, release_version: str):
+        """
+        Handles the developer preparation phase: creates release branch, updates project.yaml, commits.
+        This phase should be run from the main development branch.
+        """
+        self.logger.info(f"--- Preparing Release v{release_version} ---")
+        component_name = self.config.get("component_name", "main")
+        main_branch = self.config.get("main_branch", "main")
+        original_base_branch = self.git_service.get_current_branch()
+
+        if original_base_branch != main_branch and not self.dry_run:
+            raise GitStateError(
+                f"Release preparation must be run from the main branch ('{main_branch}'). "
+                f"Currently on '{original_base_branch}'."
+            )
+
+        if self.git_service.is_dirty() and not self.dry_run:
+            raise GitStateError(
+                "Uncommitted changes detected. Please commit or stash them before starting a release."
+            )
+
         project_yaml_path = self._path("project.yaml")
         release_branch_name = (
             f"{component_name}/releases/v{release_version}"
@@ -187,7 +189,6 @@ class ReleaseManager:
             self.logger.info(f"✓ Switched to release branch: '{release_branch_name}'")
 
             self.logger.info("Collecting data for the developer release step...")
-
             tree_id = self.git_service.write_tree()
             repo_checksum = get_reproducible_repo_hash(self.git_service, tree_id)
             self.logger.info(f"✓ Calculated repository checksum: {repo_checksum}")
@@ -195,80 +196,53 @@ class ReleaseManager:
             cert_mount = self.config.get("vault_cert_mount")
             user_cert_secret_name = self.config.get("vault_cert_secret_name")
             user_cert_secret_key = self.config.get("vault_cert_secret_key")
-            self.logger.info(
-                f"Requesting user certificate from Vault: {cert_mount}/{user_cert_secret_name}..."
-            )
             user_certificate = self.vault_service.get_certificate(
                 cert_mount, user_cert_secret_name, user_cert_secret_key
             )
-            self.logger.info("✓ User certificate obtained.")
 
-            cic_cert_secret_name = self.config.get(
-                "cic_root_ca_secret_name", "CICRootCA"
-            )
+            cic_cert_secret_name = self.config.get("cic_root_ca_secret_name", "CICRootCA")
             cic_cert_secret_key = self.config.get("vault_cert_secret_key")
-            self.logger.info(
-                f"Requesting CIC Root CA certificate from Vault: {cert_mount}/{cic_cert_secret_name}..."
-            )
             cic_root_ca_cert = self.vault_service.get_certificate(
                 cert_mount, cic_cert_secret_name, cic_cert_secret_key
             )
-            self.logger.info("✓ CIC Root CA certificate obtained.")
 
             self.logger.info("Assembling the developer-stage project.yaml metadata...")
             project_data = load_yaml(project_yaml_path) or {}
 
-            # Prepare data to be signed
             data_to_sign = {
                 "name": project_data.get("metadata", {}).get("name", "unknown"),
-                "version": release_version,  # Changed from f"v{release_version}"
+                "version": release_version,
                 "checksum": repo_checksum,
-                # Add any other relevant metadata that should be part of the signature
             }
-            # Convert to a canonical JSON string for consistent hashing
-            data_to_sign_json = json.dumps(
-                data_to_sign, sort_keys=True, separators=(",", ":")
-            )
-            data_to_sign_hash = hashlib.sha256(
-                data_to_sign_json.encode("utf-8")
-            ).digest()
+            data_to_sign_json = json.dumps(data_to_sign, sort_keys=True, separators=(",", ":"))
+            data_to_sign_hash = hashlib.sha256(data_to_sign_json.encode("utf-8")).digest()
             data_to_sign_b64 = base64.b64encode(data_to_sign_hash).decode("utf-8")
 
             vault_key_name = self.config.get("vault_key_name")
             if not vault_key_name:
-                raise ConfigurationError(
-                    "vault_key_name not found in compiler_settings."
-                )
+                raise ConfigurationError("vault_key_name not found in compiler_settings.")
 
-            self.logger.info(
-                f"Signing project metadata with Vault key: {vault_key_name}..."
-            )
             signature = self.vault_service.sign(data_to_sign_b64, vault_key_name)
             self.logger.info("✓ Project metadata signed successfully.")
 
             metadata = {
                 "name": project_data.get("metadata", {}).get("name", "unknown"),
                 "description": project_data.get("metadata", {}).get("description", ""),
-                "version": release_version,  # Changed from f"v{release_version}"
+                "version": release_version,
                 "license": project_data.get("metadata", {}).get("license", ""),
                 "owner": project_data.get("metadata", {}).get("owner", ""),
                 "tags": project_data.get("metadata", {}).get("tags", []),
                 "validatedBy": {"name": "TBD", "version": "TBD", "checksum": "TBD"},
                 "createdBy": {
-                    "name": "Gabor Zoltan Sinko",  # Placeholder, should be parsed from cert
-                    "email": "sgz@centralinfracore.hu",  # Placeholder, should be parsed from cert
+                    "name": "Gabor Zoltan Sinko",
+                    "email": "sgz@centralinfracore.hu",
                     "certificate": user_certificate,
                     "issuer_certificate": cic_root_ca_cert,
                 },
-                "build_timestamp": datetime.datetime.now(
-                    datetime.timezone.utc
-                ).isoformat(),
+                "build_timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
                 "validity": {
                     "from": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-                    "until": (
-                        datetime.datetime.now(datetime.timezone.utc)
-                        + datetime.timedelta(days=365)
-                    ).isoformat(),
+                    "until": (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365)).isoformat(),
                 },
                 "checksum": repo_checksum,
                 "sign": signature,
@@ -279,9 +253,7 @@ class ReleaseManager:
             project_data["metadata"] = metadata
 
             if self.dry_run:
-                self.logger.info(
-                    "[DRY-RUN] The following data would be written to project.yaml:"
-                )
+                self.logger.info("[DRY-RUN] The following data would be written to project.yaml:")
                 self.logger.info(yaml.dump(project_data, sort_keys=False, indent=2))
             else:
                 self.logger.info("Writing developer-stage metadata to project.yaml...")
@@ -289,109 +261,78 @@ class ReleaseManager:
                 self.logger.info("✓ project.yaml updated for developer release step.")
                 self.git_service.add(str(project_yaml_path))
 
-                commit_message = (
-                    f"release: Prepare {component_name} v{release_version} for build"
-                )
+                commit_message = f"release: Prepare {component_name} v{release_version} for build"
                 self.logger.info(f"Committing changes with message: '{commit_message}'")
                 self.git_service.run(["git", "commit", "-m", commit_message])
                 self.logger.info("✓ Developer release commit created successfully.")
 
-            self.logger.info(
-                f"✓ Release branch '{release_branch_name}' created. Proceed with build and finalization."
-            )
-            self.logger.info(
-                f"ACTION REQUIRED: You are now on branch '{release_branch_name}'."
-            )
-            self.logger.info(
-                "  1. Run your build process to generate artifacts and update 'buildHash' and 'sign' fields in project.yaml."
-            )
+            self.logger.info(f"✓ Release branch '{release_branch_name}' created. Proceed with build and finalization.")
+            self.logger.info(f"ACTION REQUIRED: You are now on branch '{release_branch_name}'.")
+            self.logger.info("  1. Run your build process to generate artifacts and update 'buildHash' in project.yaml.")
             self.logger.info("  2. Commit the updated project.yaml to this branch.")
-            self.logger.info(
-                "  3. Merge this branch into 'main' and delete this branch when done."
-            )
+            self.logger.info(f"  3. Run 'compiler close --version {release_version}' to finalize the release.")
 
-            self._check_api_accessibility(
-                "https://api.centralinfra.hu"
-            )  # This will sys.exit(0)
-
-            return release_version, component_name
         except Exception as e:
-            self.logger.critical(
-                f"Release process failed during Git operations: {e}", exc_info=True
-            )
+            self.logger.critical(f"Release preparation failed: {e}", exc_info=True)
             if not self.dry_run:
                 try:
-                    self.logger.warning(
-                        f"Attempting to clean up release branch '{release_branch_name}'."
-                    )
+                    self.logger.warning(f"Attempting to clean up by switching back to '{original_base_branch}'.")
                     self.git_service.checkout(original_base_branch)
                     self.git_service.delete_branch(release_branch_name, force=True)
-                    self.logger.info("✓ Release branch cleaned up.")
+                    self.logger.info(f"✓ Cleaned up failed release branch '{release_branch_name}'.")
                 except Exception as cleanup_e:
-                    self.logger.critical(
-                        f"Failed to clean up release branch: {cleanup_e}", exc_info=True
-                    )
-            raise ReleaseError(f"Release process failed: {e}") from e
+                    self.logger.critical(f"Failed to clean up release branch: {cleanup_e}", exc_info=True)
+            raise ReleaseError(f"Release preparation failed: {e}") from e
 
-    def _execute_finalization_phase(
-        self,
-        release_version: str,
-        component_name: str,
-        original_base_branch: str,
-        release_branch_name: str,
-    ):
+    def run_finalize_release(self, release_version: str):
         """
         Handles the finalization phase: validates project.yaml, commits, tags, merges, and cleans up.
+        This phase should be run from the release branch.
         """
-        project_yaml_path = self._path("project.yaml")
-        main_branch = self.config.get("main_branch", "main")  # Get main_branch
-
-        self.logger.info(
-            f"--- Starting Finalization for v{release_version} on branch '{release_branch_name}' ---"
+        self.logger.info(f"--- Finalizing Release v{release_version} ---")
+        component_name = self.config.get("component_name", "main")
+        main_branch = self.config.get("main_branch", "main")
+        release_branch_name = (
+            f"{component_name}/releases/v{release_version}"
+            if component_name != "main"
+            else f"releases/v{release_version}"
         )
+        current_branch = self.git_service.get_current_branch()
+
+        if current_branch != release_branch_name and not self.dry_run:
+            raise GitStateError(
+                f"Release finalization must be run from the release branch ('{release_branch_name}'). "
+                f"Currently on '{current_branch}'."
+            )
 
         self._validate_final_project_yaml()
-        self.logger.info(
-            "✓ project.yaml is fully validated and ready for finalization."
-        )
+        self.logger.info("✓ project.yaml is fully validated and ready for finalization.")
 
+        project_yaml_path = self._path("project.yaml")
         if not self.dry_run:
             if self.git_service.is_dirty():
-                self.logger.info(
-                    "Committing pending changes to project.yaml (from build process)..."
-                )
+                self.logger.info("Committing pending changes to project.yaml (from build process)...")
                 self.git_service.add(str(project_yaml_path))
                 self.git_service.run(
-                    [
-                        "git",
-                        "commit",
-                        "-m",
-                        f"release: Finalize {component_name} v{release_version} build artifacts",
-                    ]
+                    ["git", "commit", "-m", f"release: Finalize {component_name} v{release_version} build artifacts"]
                 )
             else:
-                self.logger.info(
-                    "No pending changes to project.yaml detected. Assuming manual commit of build artifacts."
-                )
+                self.logger.info("No pending changes to project.yaml detected. Assuming manual commit of build artifacts.")
 
         final_tag_name = f"{component_name}@v{release_version}"
         final_tag_message = f"Release {component_name} v{release_version}"
-        if not self.dry_run:
+        if self.dry_run:
+            self.logger.info(f"[DRY-RUN] Would create final annotated tag: '{final_tag_name}'")
+        else:
             self.logger.info(f"Creating final annotated tag: '{final_tag_name}'")
-            self.git_service.run(
-                ["git", "tag", "-a", final_tag_name, "-m", final_tag_message]
-            )
+            self.git_service.run(["git", "tag", "-a", final_tag_name, "-m", final_tag_message])
             self.logger.info("✓ Final release tag created.")
 
-        self.logger.info(
-            f"Switching back to main branch: '{main_branch}'"
-        )  # Updated log message
+        self.logger.info(f"Switching back to main branch: '{main_branch}'")
         if not self.dry_run:
-            self.git_service.checkout(main_branch)  # Checkout main_branch
+            self.git_service.checkout(main_branch)
 
-        self.logger.info(
-            f"Merging '{release_branch_name}' into '{main_branch}'"
-        )  # Updated log message
+        self.logger.info(f"Merging '{release_branch_name}' into '{main_branch}'")
         if not self.dry_run:
             self.git_service.merge(
                 release_branch_name,
@@ -403,56 +344,4 @@ class ReleaseManager:
         if not self.dry_run:
             self.git_service.delete_branch(release_branch_name)
 
-        self.logger.info(
-            f"✓ Release v{release_version} successfully finalized and merged into '{main_branch}'."
-        )  # Updated log message
-
-        return release_version, component_name
-
-    def run_release_close(self, release_version: str):
-        """
-        Orchestrates the release process based on the current Git branch and dry_run status.
-        """
-        component_name, original_base_branch = self._check_base_branch_and_version(
-            release_version, skip_git_state_checks=self.dry_run
-        )
-
-        if not self.vault_service:
-            raise VaultServiceError("VaultService is not initialized.")
-
-        main_branch = self.config.get("main_branch", "main")
-        release_branch_name = (
-            f"{component_name}/releases/v{release_version}"
-            if component_name != "main"
-            else f"releases/v{release_version}"
-        )
-
-        # If dry_run is active, always simulate the developer preparation phase
-        if self.dry_run:
-            self.logger.info("[DRY-RUN] Simulating Developer Preparation Phase.")
-            return self._execute_developer_preparation_phase(
-                release_version, component_name, original_base_branch
-            )
-
-        # Phase 1: Developer Preparation (if on main branch)
-        elif original_base_branch == main_branch:
-            return self._execute_developer_preparation_phase(
-                release_version, component_name, original_base_branch
-            )
-
-        # Phase 2: Finalization (if on a release branch)
-        elif original_base_branch == release_branch_name:
-            return self._execute_finalization_phase(
-                release_version,
-                component_name,
-                original_base_branch,
-                release_branch_name,
-            )
-
-        # Phase 3: Invalid Branch
-        else:
-            raise GitStateError(
-                f"Release command must be run from the main branch ('{main_branch}') "
-                f"to start a new release, or from an existing release branch ('{release_branch_name}') "
-                f"to finalize it. Currently on '{original_base_branch}'."
-            )
+        self.logger.info(f"✓ Release v{release_version} successfully finalized and merged into '{main_branch}'.")

--- a/tools/infra.yaml
+++ b/tools/infra.yaml
@@ -1,0 +1,133 @@
+---
+module: tools.infra
+description: ''
+tags:
+- builder
+- executor
+- loader
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: ValidationFailureError
+  kind: class
+  decorators: []
+  description: Custom exception for schema validation failures.
+  implements:
+  - ReleaseError
+  references:
+  - .releaselib.exceptions.ReleaseError
+- name: load_yaml
+  kind: function
+  decorators: []
+  description: Loads a YAML file.
+  references:
+  - .releaselib.exceptions.ConfigurationError
+  - yaml.YAMLError
+  - yaml.safe_load
+  calls:
+  - .releaselib.exceptions.ConfigurationError
+  - content.strip
+  - f.read
+  - yaml.safe_load
+- name: write_yaml
+  kind: function
+  decorators: []
+  description: Writes data to a YAML file atomically.
+  references:
+  - .releaselib.exceptions.ReleaseError
+  - yaml.dump
+  calls:
+  - .releaselib.exceptions.ReleaseError
+  - yaml.dump
+- name: get_reproducible_repo_hash
+  kind: function
+  decorators: []
+  description: Calculates a reproducible SHA256 hash of a given git tree object.
+  references:
+  - .releaselib.exceptions.ReleaseError
+  calls:
+  - .releaselib.exceptions.ReleaseError
+  - git_service.archive_tree_bytes
+  - hasher.digest
+  - hasher.update
+- name: ReleaseManager
+  kind: class
+  decorators: []
+  description: ''
+  implements: []
+  references: []
+- name: __init__
+  kind: method
+  receiver: ReleaseManager
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - project_root.resolve
+- name: _path
+  kind: method
+  receiver: ReleaseManager
+  decorators: []
+  description: ''
+  references: []
+  calls: []
+- name: _validate_final_project_yaml
+  kind: method
+  receiver: ReleaseManager
+  decorators: []
+  description: Validates the project.yaml against the project.schema.yaml.
+  references:
+  - .releaselib.exceptions.ReleaseError
+  - jsonschema.ValidationError
+  - .releaselib.exceptions.ConfigurationError
+  - jsonschema.validate
+  calls:
+  - .releaselib.exceptions.ConfigurationError
+  - .releaselib.exceptions.ReleaseError
+  - ValidationFailureError
+  - jsonschema.validate
+  - self._path
+- name: run_check
+  kind: method
+  receiver: ReleaseManager
+  decorators: []
+  description: Performs pre-flight checks for a release.
+  references:
+  - .releaselib.exceptions.VaultServiceError
+  - .releaselib.exceptions.GitStateError
+  calls:
+  - .releaselib.exceptions.GitStateError
+  - .releaselib.exceptions.VaultServiceError
+- name: run_prepare_release
+  kind: method
+  receiver: ReleaseManager
+  decorators: []
+  description: 'Handles the developer preparation phase: creates release branch, updates
+    project.yaml, commits. This phase should be run from the main development branch.'
+  references:
+  - .releaselib.exceptions.ReleaseError
+  - yaml.dump
+  - .releaselib.exceptions.ConfigurationError
+  - .releaselib.exceptions.GitStateError
+  calls:
+  - .releaselib.exceptions.ConfigurationError
+  - .releaselib.exceptions.GitStateError
+  - .releaselib.exceptions.ReleaseError
+  - data_to_sign_json.encode
+  - project_data.get
+  - self._path
+  - yaml.dump
+- name: run_finalize_release
+  kind: method
+  receiver: ReleaseManager
+  decorators: []
+  description: 'Handles the finalization phase: validates project.yaml, commits, tags,
+    merges, and cleans up. This phase should be run from the release branch.'
+  references:
+  - .releaselib.exceptions.GitStateError
+  calls:
+  - .releaselib.exceptions.GitStateError
+  - self._path
+  - self._validate_final_project_yaml

--- a/tools/init-hooks.sh
+++ b/tools/init-hooks.sh
@@ -38,4 +38,14 @@ echo "[*] Symlinking commit-msg hook from tools directory..."
 ln -s -f "../../tools/git_hook_commit-msg.sh" "$COMMIT_MSG_HOOK"
 echo "  ✓ Done."
 
+# Set up post-commit hook for companion YAML auto-merge
+POST_COMMIT_HOOK="$HOOKS_DIR/post-commit"
+if [ -f "$POST_COMMIT_HOOK" ]; then
+    echo "[INFO] A post-commit hook already exists. Backing it up to post-commit.bak."
+    mv "$POST_COMMIT_HOOK" "$POST_COMMIT_HOOK.bak"
+fi
+echo "[*] Symlinking post-commit hook from tools directory..."
+ln -s -f "../../tools/git_hook_post-commit.sh" "$POST_COMMIT_HOOK"
+echo "  ✓ Done."
+
 echo "\nRepository initialization complete. Hooks are set up."

--- a/tools/orchestrator.py
+++ b/tools/orchestrator.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""
+CIC Agent Orchestrator
+
+Deterministic, zero-token agent runner built on PROMPTMAP.yaml task queue.
+
+Flow:
+  1. Parse PROMPTMAP → pick next todo task (highest priority)
+  2. Load task profile (task_profile field) + scope profile (scope_profile field)
+  3. Build agent briefing from profiles + task prompt
+  4. Print briefing to stdout (agent reads it) or spawn subprocess
+  5. Run accept gate (accept field from task)
+  6. On exit 0 → mark task done; on fail → mark task failed (max retries)
+
+Usage:
+  python orchestrator.py --repo CIC-Relay --sprint 15
+  python orchestrator.py --repo CIC-Relay --task upstream-source-http --print-briefing
+  python orchestrator.py --list-tasks --repo CIC-Relay --status todo
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+# --- Configuration ---
+
+PROFILES_BASE = Path(__file__).parent.parent / "ai" / "profiles"
+TASK_PROFILES_DIR = PROFILES_BASE / "task"
+SCOPE_PROFILES_DIR = PROFILES_BASE / "scope"
+
+# Colon-separated list of PROMPTMAP.yaml paths; if unset, scanned from SOURCE_DIR.
+PROMPTMAP_PATHS_ENV = os.environ.get("PROMPTMAP_PATHS", "")
+SOURCE_DIR = Path(os.environ.get("SOURCE_DIR", str(Path(__file__).parent.parent / "source")))
+
+MAX_RETRIES = int(os.environ.get("ORCHESTRATOR_MAX_RETRIES", "2"))
+
+
+# --- PROMPTMAP helpers ---
+
+def find_promptmaps() -> list[Path]:
+    if PROMPTMAP_PATHS_ENV:
+        return [Path(p) for p in PROMPTMAP_PATHS_ENV.split(":") if p.strip()]
+    return list(SOURCE_DIR.rglob("PROMPTMAP.yaml"))
+
+
+def _repo_name(path: Path) -> str:
+    parts = path.parts
+    try:
+        idx = list(parts).index("ai")
+        return parts[idx - 1] if idx > 0 else path.parent.parent.name
+    except ValueError:
+        return path.parent.parent.name
+
+
+def iter_tasks(data: dict, sprint: Optional[int] = None):
+    """Yield (sprint_num, task_dict) from a PROMPTMAP structure."""
+    for entry in data.get("entries", []):
+        if isinstance(entry, dict):
+            yield None, entry
+    for block in data.get("sprints", []):
+        snum = block.get("sprint")
+        for task in block.get("tasks", []):
+            if sprint is None or snum == sprint:
+                yield snum, task
+    if "sprint" in data and "tasks" in data:
+        snum = data["sprint"]
+        for task in data["tasks"]:
+            if sprint is None or snum == sprint:
+                yield snum, task
+
+
+def load_tasks(repo: str = "", sprint: Optional[int] = None, status: Optional[str] = None) -> list[dict]:
+    results = []
+    for pm_path in find_promptmaps():
+        rname = _repo_name(pm_path)
+        if repo and repo.lower() not in rname.lower():
+            continue
+        with pm_path.open() as f:
+            data = yaml.safe_load(f) or {}
+        for snum, task in iter_tasks(data, sprint):
+            if not isinstance(task, dict):
+                continue
+            if status and task.get("status") != status:
+                continue
+            results.append({"repo": rname, "sprint": snum, "pm_path": str(pm_path), **task})
+    results.sort(key=lambda x: (x.get("priority") is None, x.get("priority") or 0))
+    return results
+
+
+def update_task_status(pm_path: Path, task_id: str, new_status: str, extra: Optional[dict] = None) -> bool:
+    with pm_path.open() as f:
+        data = yaml.safe_load(f) or {}
+    found = False
+
+    def patch(task: dict) -> None:
+        nonlocal found
+        if task.get("task") == task_id:
+            task["status"] = new_status
+            if extra:
+                task.update(extra)
+            found = True
+
+    for entry in data.get("entries", []):
+        if isinstance(entry, dict):
+            patch(entry)
+    for block in data.get("sprints", []):
+        for task in block.get("tasks", []):
+            if isinstance(task, dict):
+                patch(task)
+    if "tasks" in data:
+        for task in data["tasks"]:
+            if isinstance(task, dict):
+                patch(task)
+
+    if found:
+        with pm_path.open("w") as f:
+            yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+    return found
+
+
+# --- Profile helpers ---
+
+def load_profile(profiles_dir: Path, name: str) -> dict:
+    p = profiles_dir / f"{name}.yaml"
+    if not p.exists():
+        return {}
+    with p.open() as f:
+        return yaml.safe_load(f) or {}
+
+
+# --- Briefing builder ---
+
+def build_briefing(task: dict, task_profile: dict, scope_profile: dict) -> str:
+    lines = ["# CIC Agent Briefing", ""]
+    lines += [f"**Repo**: {task.get('repo', '?')}"]
+    lines += [f"**Sprint**: {task.get('sprint', '?')}  |  **Task**: {task.get('task', '?')}  |  **Priority**: {task.get('priority', '?')}"]
+    if task.get("milestone"):
+        lines += [f"**Milestone**: {task['milestone']}"]
+    lines += [""]
+
+    if task_profile:
+        lines += ["## Task Profile: " + task_profile.get("profile", "?"), ""]
+        lines += [task_profile.get("description", "").strip(), ""]
+        if task_profile.get("boot_sequence"):
+            lines += ["### Boot sequence"]
+            for step in task_profile["boot_sequence"]:
+                lines += [f"  - {step}"]
+            lines += [""]
+        if task_profile.get("forbidden"):
+            lines += ["### Forbidden"]
+            for item in task_profile["forbidden"]:
+                lines += [f"  - {item}"]
+            lines += [""]
+
+    if scope_profile:
+        lines += ["## Scope Profile: " + scope_profile.get("scope", "?"), ""]
+        lines += [scope_profile.get("description", "").strip(), ""]
+        if scope_profile.get("owns"):
+            lines += ["**Owns**: " + ", ".join(scope_profile["owns"])]
+        if scope_profile.get("reads"):
+            lines += ["**Reads**: " + ", ".join(scope_profile["reads"])]
+        if scope_profile.get("test_cmd"):
+            lines += ["**Test cmd**: `" + scope_profile["test_cmd"] + "`"]
+        if scope_profile.get("coverage_min"):
+            lines += [f"**Coverage min**: {scope_profile['coverage_min']}%"]
+        if scope_profile.get("invariants"):
+            lines += ["", "### Scope invariants"]
+            for inv in scope_profile["invariants"]:
+                lines += [f"  - {inv}"]
+        if scope_profile.get("mcp_focus_queries"):
+            lines += ["", "### MCP focus queries (run these first)"]
+            for q in scope_profile["mcp_focus_queries"]:
+                lines += [f"  - `focus_pack(\"{q}\")`"]
+        lines += [""]
+
+    lines += ["## Task Prompt", ""]
+    lines += [task.get("prompt", "").strip(), ""]
+
+    if task.get("tests"):
+        lines += ["## Tests to touch"]
+        for t in task["tests"]:
+            lines += [f"  - {t}"]
+        lines += [""]
+
+    if task.get("accept"):
+        lines += ["## Accept gate", ""]
+        lines += [f"```bash", task.get("accept", "").strip(), "```", ""]
+
+    return "\n".join(lines)
+
+
+# --- Accept gate runner ---
+
+def run_accept_gate(accept_cmd: str, cwd: Optional[str] = None) -> int:
+    print(f"\n[orchestrator] Running accept gate: {accept_cmd}", file=sys.stderr)
+    result = subprocess.run(accept_cmd, shell=True, cwd=cwd)
+    return result.returncode
+
+
+# --- Main ---
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CIC Agent Orchestrator")
+    parser.add_argument("--repo", default="", help="Filter by repo name substring")
+    parser.add_argument("--sprint", type=int, default=None, help="Filter by sprint number")
+    parser.add_argument("--task", default="", help="Specific task ID to run")
+    parser.add_argument("--status", default="todo", help="Task status filter (default: todo)")
+    parser.add_argument("--list-tasks", action="store_true", help="List tasks and exit")
+    parser.add_argument("--print-briefing", action="store_true", help="Print briefing and exit (no accept gate)")
+    parser.add_argument("--accept-cwd", default="", help="Working directory for accept gate command")
+    args = parser.parse_args()
+
+    if args.list_tasks:
+        tasks = load_tasks(repo=args.repo, sprint=args.sprint, status=args.status or None)
+        for t in tasks:
+            print(f"[{t.get('status','?'):12}] pri={t.get('priority','?'):3}  {t.get('repo','?')}  sprint={t.get('sprint','?')}  task={t.get('task','?')}")
+        print(f"\n{len(tasks)} task(s)")
+        return
+
+    # Select task
+    if args.task:
+        tasks = load_tasks(repo=args.repo)
+        task = next((t for t in tasks if t.get("task") == args.task), None)
+        if task is None:
+            print(f"[orchestrator] Task not found: {args.task}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        tasks = load_tasks(repo=args.repo, sprint=args.sprint, status="todo")
+        if not tasks:
+            print("[orchestrator] No todo tasks found.", file=sys.stderr)
+            sys.exit(0)
+        task = tasks[0]
+
+    task_profile_name = task.get("task_profile", "implement")
+    scope_profile_name = task.get("scope_profile", "")
+
+    task_profile = load_profile(TASK_PROFILES_DIR, task_profile_name) if task_profile_name else {}
+    scope_profile = load_profile(SCOPE_PROFILES_DIR, scope_profile_name) if scope_profile_name else {}
+
+    briefing = build_briefing(task, task_profile, scope_profile)
+    print(briefing)
+
+    if args.print_briefing:
+        return
+
+    # Accept gate
+    accept_cmd = task.get("accept", "")
+    if not accept_cmd:
+        print("[orchestrator] No accept gate defined — marking done.", file=sys.stderr)
+        update_task_status(Path(task["pm_path"]), task["task"], "done")
+        return
+
+    cwd = args.accept_cwd or None
+    for attempt in range(1, MAX_RETRIES + 1):
+        rc = run_accept_gate(accept_cmd, cwd=cwd)
+        if rc == 0:
+            update_task_status(Path(task["pm_path"]), task["task"], "done",
+                               {"result": f"accept gate passed on attempt {attempt}"})
+            print(f"[orchestrator] Task '{task['task']}' DONE.", file=sys.stderr)
+            return
+        print(f"[orchestrator] Accept gate failed (attempt {attempt}/{MAX_RETRIES})", file=sys.stderr)
+
+    update_task_status(Path(task["pm_path"]), task["task"], "failed",
+                       {"failure_reason": f"accept gate failed after {MAX_RETRIES} attempts"})
+    print(f"[orchestrator] Task '{task['task']}' FAILED.", file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/orchestrator.yaml
+++ b/tools/orchestrator.yaml
@@ -1,0 +1,134 @@
+---
+module: tools.orchestrator
+description: 'CIC Agent Orchestrator Deterministic, zero-token agent runner built
+  on PROMPTMAP.yaml task queue. Flow: 1. Parse PROMPTMAP → pick next todo task (highest
+  priority) 2. Load task profile (task_profile field) + scope profile (scope_profile
+  field) 3. Build agent briefing from profiles + task prompt 4. Print briefing to
+  stdout (agent reads it) or spawn subprocess 5. Run accept gate (accept field from
+  task) 6. On exit 0 → mark task done; on fail → mark task failed (max retries) Usage:
+  python orchestrator.py --repo CIC-Relay --sprint 15 python orchestrator.py --repo
+  CIC-Relay --task upstream-source-http --print-briefing python orchestrator.py --list-tasks
+  --repo CIC-Relay --status todo'
+tags:
+- builder
+- core
+- executor
+- loader
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: PROFILES_BASE
+  kind: const
+  description: ''
+  references: []
+- name: TASK_PROFILES_DIR
+  kind: const
+  description: ''
+  references: []
+- name: SCOPE_PROFILES_DIR
+  kind: const
+  description: ''
+  references: []
+- name: PROMPTMAP_PATHS_ENV
+  kind: const
+  description: ''
+  references: []
+- name: SOURCE_DIR
+  kind: const
+  description: ''
+  references: []
+- name: MAX_RETRIES
+  kind: const
+  description: ''
+  references: []
+- name: find_promptmaps
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - PROMPTMAP_PATHS_ENV.split
+  - SOURCE_DIR.rglob
+  - p.strip
+- name: _repo_name
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls: []
+- name: iter_tasks
+  kind: function
+  decorators: []
+  description: Yield (sprint_num, task_dict) from a PROMPTMAP structure.
+  references: []
+  calls:
+  - block.get
+  - data.get
+- name: load_tasks
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - yaml.safe_load
+  calls:
+  - _repo_name
+  - pm_path.open
+  - repo.lower
+  - results.append
+  - results.sort
+  - rname.lower
+  - task.get
+  - x.get
+  - yaml.safe_load
+- name: update_task_status
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - yaml.dump
+  - yaml.safe_load
+  calls:
+  - block.get
+  - data.get
+  - pm_path.open
+  - task.get
+  - task.update
+  - yaml.dump
+  - yaml.safe_load
+- name: load_profile
+  kind: function
+  decorators: []
+  description: ''
+  references:
+  - yaml.safe_load
+  calls:
+  - p.exists
+  - p.open
+  - yaml.safe_load
+- name: build_briefing
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - scope_profile.get
+  - task.get
+  - task_profile.get
+- name: run_accept_gate
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls: []
+- name: main
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+  calls:
+  - parser.add_argument
+  - parser.parse_args
+  - t.get
+  - task.get

--- a/tools/py.meta.gen.py
+++ b/tools/py.meta.gen.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""py.meta.gen.py — Companion YAML skeleton generator for Python source files.
+
+Parses Python source files (via the `ast` module) and generates a .yaml companion
+following py.meta.schema.yaml.
+
+Auto-filled fields:
+  - module, entrypoint
+  - objects: name, kind, receiver, decorators, references
+  - description: extracted from module/class/function docstrings
+  - tags: suggested from file path, imports, and naming conventions (review before use)
+
+Semantic fields left empty for human completion:
+  - category, used_in, related_nodes, implements
+
+Usage:
+    python tools/py.meta.gen.py <file.py> [<file.py> ...]
+    python tools/py.meta.gen.py --dir <directory> [--recursive] [--overwrite]
+
+Options:
+    --dir         Process all .py files in directory (default: non-recursive)
+    --recursive   Recurse into subdirectories (use with --dir); skips
+                  p_venv/__pycache__/.git/.idea/.pytest_cache/node_modules
+    --overwrite   Overwrite existing .yaml files (default: skip)
+    --merge       Update auto fields while preserving manual fields (tags,
+                  category, used_in, related_nodes, implements)
+    --skip-tests  Skip test_*.py / *_test.py files (default: include)
+    --dry-run     Print what would be generated without writing files
+"""
+
+import ast
+import re
+import sys
+import argparse
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML not found. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+# Allowed tag values from py.meta.schema.yaml — same vocabulary as go.meta.schema.yaml
+# so tag-based graph queries work across both languages.
+_ALLOWED_TAGS = {
+    "relay", "compliance", "workflow", "cictor", "schema", "parser", "guard",
+    "core", "doc", "interface", "gateway", "builder", "test", "meta",
+    "orchestrator", "decision", "reflector", "context", "validator", "executor",
+    "hook", "template", "fallback", "session", "metrics", "storage", "loader",
+    "renderer", "platform-engineering", "ci-cd", "ecosystem",
+}
+
+# Directories skipped during --dir --recursive scans.
+_SKIP_DIRS = {"p_venv", "__pycache__", ".git", ".idea", ".pytest_cache", "node_modules"}
+
+# Fallback stdlib root list for Python < 3.10 (no sys.stdlib_module_names).
+_FALLBACK_STDLIB = {
+    "abc", "argparse", "ast", "asyncio", "base64", "collections", "configparser",
+    "contextlib", "copy", "csv", "dataclasses", "datetime", "decimal", "enum",
+    "functools", "glob", "hashlib", "io", "itertools", "json", "logging", "math",
+    "multiprocessing", "os", "pathlib", "pickle", "platform", "random", "re",
+    "shutil", "socket", "sqlite3", "string", "subprocess", "sys", "tempfile",
+    "textwrap", "threading", "time", "traceback", "typing", "unittest", "urllib",
+    "uuid", "warnings", "xml", "zipfile",
+}
+
+
+def _stdlib_set() -> set[str]:
+    names = getattr(sys, "stdlib_module_names", None)
+    return set(names) if names else set(_FALLBACK_STDLIB)
+
+
+# ---------------------------------------------------------------------------
+# Import parsing
+# ---------------------------------------------------------------------------
+
+def _parse_imports(tree: ast.Module) -> dict[str, str]:
+    """Return {local_alias: fully_qualified_target} for module-level imports.
+
+    `import yaml`            -> {"yaml": "yaml"}
+    `import numpy as np`     -> {"np": "numpy"}
+    `from pathlib import Path` -> {"Path": "pathlib.Path"}
+    `from . import foo`      -> {"foo": ".foo"}  (relative — treated as local/non-stdlib)
+    """
+    imports: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname:
+                    imports[alias.asname] = alias.name
+                else:
+                    top = alias.name.split(".")[0]
+                    imports[top] = top
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                origin = "." * node.level + (node.module or "")
+                for alias in node.names:
+                    local = alias.asname or alias.name
+                    imports[local] = f"{origin}.{alias.name}"
+            else:
+                module = node.module or ""
+                for alias in node.names:
+                    local = alias.asname or alias.name
+                    imports[local] = f"{module}.{alias.name}" if module else alias.name
+    return imports
+
+
+def _is_stdlib(target: str, stdlib: set[str]) -> bool:
+    if not target or target.startswith("."):
+        return False
+    return target.split(".")[0] in stdlib
+
+
+# ---------------------------------------------------------------------------
+# Reference extraction
+# ---------------------------------------------------------------------------
+
+def _iter_subtree(node: ast.AST, skip_kinds: tuple = ()):
+    stack = list(ast.iter_child_nodes(node))
+    while stack:
+        n = stack.pop()
+        if skip_kinds and isinstance(n, skip_kinds):
+            continue
+        yield n
+        stack.extend(ast.iter_child_nodes(n))
+
+
+def _extract_refs(node: ast.AST, imports: dict[str, str], stdlib: set[str],
+                   skip_kinds: tuple = ()) -> list[str]:
+    """Find non-stdlib references in node's subtree.
+
+    Two passes mirroring go.meta.gen.py's approach:
+    1. Attribute access on an imported module alias: yaml.safe_load -> "yaml.safe_load"
+    2. Bare use of a from-imported name: Path(...) where "from pathlib import Path"
+       -> "pathlib.Path" (filtered out if the origin is stdlib)
+    """
+    seen: dict[str, None] = {}
+    for n in _iter_subtree(node, skip_kinds):
+        if isinstance(n, ast.Attribute) and isinstance(n.value, ast.Name):
+            alias = n.value.id
+            target = imports.get(alias)
+            if target and not _is_stdlib(target, stdlib):
+                seen[f"{target}.{n.attr}"] = None
+        elif isinstance(n, ast.Name):
+            target = imports.get(n.id)
+            if target and "." in target and not _is_stdlib(target, stdlib):
+                seen[target] = None
+    return list(seen)
+
+
+# ---------------------------------------------------------------------------
+# Decorator / docstring helpers
+# ---------------------------------------------------------------------------
+
+def _dotted_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    return ""
+
+
+def _decorator_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Call):
+        return _dotted_name(node.func)
+    return _dotted_name(node)
+
+
+def _decorators(node) -> list[str]:
+    return [d for d in (_decorator_name(n) for n in node.decorator_list) if d]
+
+
+def _clean_doc(doc: str | None) -> str:
+    if not doc:
+        return ""
+    lines = [line.strip() for line in doc.strip().splitlines() if line.strip()]
+    return " ".join(lines)
+
+
+def _has_main_guard(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            test = node.test
+            if (isinstance(test, ast.Compare) and isinstance(test.left, ast.Name)
+                    and test.left.id == "__name__"):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tag suggestion
+# ---------------------------------------------------------------------------
+
+def _suggest_tags(py_file: Path, imports: dict[str, str], objects: list[dict]) -> list[str]:
+    """Suggest tags from file path, imports, and object naming conventions.
+    Returns a sorted list of allowed tag values (see py.meta.schema.yaml).
+    These are suggestions — review and trim before committing the YAML.
+    """
+    tags: set[str] = set()
+    path_str = str(py_file).replace("\\", "/")
+    filename = py_file.name
+
+    if "/tools/" in path_str or path_str.startswith("tools/"):
+        tags.add("builder")
+    if filename.startswith("test_") or filename.endswith("_test.py"):
+        tags.add("test")
+    if "mcp-server" in path_str or filename == "server.py":
+        tags.update(["gateway", "interface"])
+    if filename == "make_source.py":
+        tags.update(["builder", "core"])
+
+    origins = set(imports.values())
+    if any(o.split(".")[0] == "sqlite3" for o in origins):
+        tags.add("storage")
+    if any(o.split(".")[0] == "argparse" for o in origins):
+        tags.add("core")
+
+    for obj in objects:
+        name = obj["name"]
+        if re.match(r"^[Vv]alidate", name):
+            tags.add("validator")
+        if re.match(r"^([Ee]xecute|[Rr]un)", name):
+            tags.add("executor")
+        if re.match(r"^[Ll]oad", name):
+            tags.add("loader")
+        if re.search(r"^hook|Hook$", name):
+            tags.add("hook")
+        if re.search(r"[Mm]etric", name):
+            tags.add("metrics")
+        if re.search(r"[Ss]chema", name):
+            tags.add("schema")
+        if re.match(r"^[Pp]arse", name):
+            tags.add("parser")
+        if "mcp.tool" in obj.get("decorators", []):
+            tags.add("interface")
+
+    return sorted(tags & _ALLOWED_TAGS)
+
+
+# ---------------------------------------------------------------------------
+# Object parsing
+# ---------------------------------------------------------------------------
+
+def _parse_objects(tree: ast.Module, imports: dict[str, str], stdlib: set[str]) -> list[dict]:
+    objects: list[dict] = []
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            bases = [b for b in (_dotted_name(n) for n in node.bases) if b]
+            objects.append({
+                "name": node.name,
+                "kind": "class",
+                "decorators": _decorators(node),
+                "description": _clean_doc(ast.get_docstring(node)),
+                "implements": bases,
+                "references": _extract_refs(node, imports, stdlib,
+                                             skip_kinds=(ast.FunctionDef, ast.AsyncFunctionDef)),
+            })
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    objects.append({
+                        "name": sub.name,
+                        "kind": "method",
+                        "receiver": node.name,
+                        "decorators": _decorators(sub),
+                        "description": _clean_doc(ast.get_docstring(sub)),
+                        "references": _extract_refs(sub, imports, stdlib),
+                    })
+
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            objects.append({
+                "name": node.name,
+                "kind": "function",
+                "decorators": _decorators(node),
+                "description": _clean_doc(ast.get_docstring(node)),
+                "references": _extract_refs(node, imports, stdlib),
+            })
+
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    objects.append({"name": target.id, "kind": "const",
+                                     "description": "", "references": []})
+
+    return objects
+
+
+# ---------------------------------------------------------------------------
+# Module name resolution
+# ---------------------------------------------------------------------------
+
+def _module_name(py_file: Path) -> str:
+    """Walk up while sibling __init__.py files exist (package convention)."""
+    parts = [py_file.stem]
+    parent = py_file.parent
+    while (parent / "__init__.py").exists():
+        parts.insert(0, parent.name)
+        parent = parent.parent
+    return ".".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Main generator
+# ---------------------------------------------------------------------------
+
+def generate(py_file: Path) -> dict:
+    source = py_file.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(py_file))
+    stdlib = _stdlib_set()
+    imports = _parse_imports(tree)
+    objects = _parse_objects(tree, imports, stdlib)
+
+    return {
+        "module": _module_name(py_file),
+        "description": _clean_doc(ast.get_docstring(tree)),
+        "tags": _suggest_tags(py_file, imports, objects),
+        "category": [],
+        "used_in": [],
+        "entrypoint": _has_main_guard(tree),
+        "related_nodes": [],
+        "objects": objects,
+    }
+
+
+def _merge_data(new_data: dict, old_data: dict) -> dict:
+    """Merge freshly generated data into an existing YAML.
+
+    Auto fields (always updated from source):
+      module, entrypoint, objects.references, objects.kind, objects.receiver,
+      objects.decorators
+
+    Description fields (updated only if a docstring exists in source):
+      description (file-level), objects[].description
+      If the new description is empty, the existing value is preserved.
+
+    Manual fields (never touched):
+      tags, category, used_in, related_nodes, objects[].implements
+
+    Objects:
+      - New objects (added to source) -> appended
+      - Removed objects (deleted from source) -> dropped
+      - Existing objects -> merged per field rules above
+    """
+    merged = dict(new_data)
+
+    merged["tags"] = old_data.get("tags", new_data.get("tags", []))
+    merged["category"] = old_data.get("category", [])
+    merged["used_in"] = old_data.get("used_in", [])
+    merged["related_nodes"] = old_data.get("related_nodes", [])
+
+    if not merged.get("description"):
+        merged["description"] = old_data.get("description", "")
+
+    old_by_name: dict[str, dict] = {o["name"]: o for o in old_data.get("objects", [])}
+    merged_objects = []
+    for new_obj in new_data.get("objects", []):
+        name = new_obj["name"]
+        if name in old_by_name:
+            old_obj = old_by_name[name]
+            obj = dict(new_obj)
+            if obj.get("kind") == "class":
+                obj["implements"] = old_obj.get("implements", [])
+            if not obj.get("description"):
+                obj["description"] = old_obj.get("description", "")
+        else:
+            obj = new_obj
+        merged_objects.append(obj)
+
+    merged["objects"] = merged_objects
+    return merged
+
+
+def _write_yaml(data: dict, path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("---\n")
+        yaml.dump(data, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate companion YAML skeletons for Python source files.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("files", nargs="*", metavar="FILE", help="Python source files to process")
+    parser.add_argument("--dir", metavar="DIR", help="Process all .py files in DIR")
+    parser.add_argument("--recursive", action="store_true",
+                        help="Recurse into subdirectories (use with --dir)")
+    parser.add_argument("--overwrite", action="store_true",
+                        help="Overwrite existing YAML files completely")
+    parser.add_argument("--merge", action="store_true",
+                        help="Update auto fields while preserving manual fields "
+                             "(tags, category, used_in, related_nodes, implements). "
+                             "Implies --overwrite for existing files.")
+    parser.add_argument("--skip-tests", action="store_true",
+                        help="Skip test_*.py / *_test.py files")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print actions without writing files")
+    args = parser.parse_args()
+
+    files: list[Path] = [Path(f) for f in args.files]
+    if args.dir:
+        d = Path(args.dir)
+        glob = d.rglob("*.py") if args.recursive else d.glob("*.py")
+        for f in glob:
+            if args.recursive and _SKIP_DIRS & set(f.relative_to(d).parts[:-1]):
+                continue
+            files.append(f)
+
+    if not files:
+        parser.print_help()
+        sys.exit(1)
+
+    generated = merged_count = skipped = errors = 0
+    for py_file in sorted(set(files)):
+        if not py_file.exists():
+            print(f"NOT FOUND: {py_file}", file=sys.stderr)
+            errors += 1
+            continue
+        if args.skip_tests and (py_file.name.startswith("test_") or py_file.name.endswith("_test.py")):
+            continue
+
+        yaml_file = py_file.with_suffix(".yaml")
+        existing = yaml_file.exists()
+
+        if existing and not args.overwrite and not args.merge:
+            print(f"SKIP (exists): {yaml_file}")
+            skipped += 1
+            continue
+
+        try:
+            data = generate(py_file)
+        except SyntaxError as e:
+            print(f"ERROR: {py_file}: {e}", file=sys.stderr)
+            errors += 1
+            continue
+
+        if existing and args.merge:
+            try:
+                with open(yaml_file) as f:
+                    old_data = yaml.safe_load(f) or {}
+                data = _merge_data(data, old_data)
+                action = "MERGED"
+                merged_count += 1
+            except Exception as e:
+                print(f"ERROR reading existing {yaml_file}: {e}", file=sys.stderr)
+                errors += 1
+                continue
+        else:
+            action = "GENERATED"
+            generated += 1
+
+        obj_count = len(data["objects"])
+        ref_count = sum(len(o.get("references", [])) for o in data["objects"])
+
+        if args.dry_run:
+            print(f"DRY-RUN ({action}): {yaml_file}  [{obj_count} objects, {ref_count} refs]")
+        else:
+            _write_yaml(data, yaml_file)
+            print(f"{action}: {yaml_file}  [{obj_count} objects, {ref_count} refs]")
+
+    summary = f"\nDone: {generated} generated, {merged_count} merged, {skipped} skipped, {errors} errors"
+    print(summary)
+    if errors:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/py.meta.gen.py
+++ b/tools/py.meta.gen.py
@@ -161,6 +161,39 @@ def _dotted_name(node: ast.AST) -> str:
     return ""
 
 
+def _extract_calls(node: ast.AST, imports: dict[str, str], stdlib: set[str]) -> list[str]:
+    """Extract non-stdlib function/method calls from the given AST node subtree.
+
+    Resolves through imports:
+    - yaml.safe_load(...)  -> yaml.safe_load  (from: import yaml)
+    - Path(...)            -> pathlib.Path    (from: from pathlib import Path)
+    - local_func(...)      -> local_func      (same-module, kept for graph edges)
+    """
+    calls: dict[str, None] = {}
+    for n in _iter_subtree(node):
+        if not isinstance(n, ast.Call):
+            continue
+        func = n.func
+        if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+            alias = func.value.id
+            target = imports.get(alias)
+            if target:
+                if not _is_stdlib(target, stdlib):
+                    calls[f"{target}.{func.attr}"] = None
+            else:
+                # Local variable or same-module object — keep for intra-module edges
+                calls[f"{alias}.{func.attr}"] = None
+        elif isinstance(func, ast.Name):
+            target = imports.get(func.id)
+            if target:
+                if not _is_stdlib(target, stdlib):
+                    calls[target] = None
+            elif func.id[0].isupper() or func.id.startswith("_"):
+                # Capitalized = likely class/constructor; underscore = module-private helper
+                calls[func.id] = None
+    return sorted(calls)
+
+
 def _decorator_name(node: ast.AST) -> str:
     if isinstance(node, ast.Call):
         return _dotted_name(node.func)
@@ -266,6 +299,7 @@ def _parse_objects(tree: ast.Module, imports: dict[str, str], stdlib: set[str]) 
                         "decorators": _decorators(sub),
                         "description": _clean_doc(ast.get_docstring(sub)),
                         "references": _extract_refs(sub, imports, stdlib),
+                        "calls": _extract_calls(sub, imports, stdlib),
                     })
 
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -275,6 +309,7 @@ def _parse_objects(tree: ast.Module, imports: dict[str, str], stdlib: set[str]) 
                 "decorators": _decorators(node),
                 "description": _clean_doc(ast.get_docstring(node)),
                 "references": _extract_refs(node, imports, stdlib),
+                "calls": _extract_calls(node, imports, stdlib),
             })
 
         elif isinstance(node, ast.Assign):

--- a/tools/py.meta.gen.yaml
+++ b/tools/py.meta.gen.yaml
@@ -1,0 +1,136 @@
+---
+module: tools.py.meta.gen
+description: 'py.meta.gen.py — Companion YAML skeleton generator for Python source
+  files. Parses Python source files (via the `ast` module) and generates a .yaml companion
+  following py.meta.schema.yaml. Auto-filled fields: - module, entrypoint - objects:
+  name, kind, receiver, decorators, references - description: extracted from module/class/function
+  docstrings - tags: suggested from file path, imports, and naming conventions (review
+  before use) Semantic fields left empty for human completion: - category, used_in,
+  related_nodes, implements Usage: python tools/py.meta.gen.py <file.py> [<file.py>
+  ...] python tools/py.meta.gen.py --dir <directory> [--recursive] [--overwrite] Options:
+  --dir         Process all .py files in directory (default: non-recursive) --recursive   Recurse
+  into subdirectories (use with --dir); skips p_venv/__pycache__/.git/.idea/.pytest_cache/node_modules
+  --overwrite   Overwrite existing .yaml files (default: skip) --merge       Update
+  auto fields while preserving manual fields (tags, category, used_in, related_nodes,
+  implements) --skip-tests  Skip test_*.py / *_test.py files (default: include) --dry-run     Print
+  what would be generated without writing files'
+tags:
+- builder
+- core
+category: []
+used_in: []
+entrypoint: true
+related_nodes: []
+objects:
+- name: _ALLOWED_TAGS
+  kind: const
+  description: ''
+  references: []
+- name: _SKIP_DIRS
+  kind: const
+  description: ''
+  references: []
+- name: _FALLBACK_STDLIB
+  kind: const
+  description: ''
+  references: []
+- name: _stdlib_set
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _parse_imports
+  kind: function
+  decorators: []
+  description: 'Return {local_alias: fully_qualified_target} for module-level imports.
+    `import yaml`            -> {"yaml": "yaml"} `import numpy as np`     -> {"np":
+    "numpy"} `from pathlib import Path` -> {"Path": "pathlib.Path"} `from . import
+    foo`      -> {"foo": ".foo"}  (relative — treated as local/non-stdlib)'
+  references: []
+- name: _is_stdlib
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _iter_subtree
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _extract_refs
+  kind: function
+  decorators: []
+  description: 'Find non-stdlib references in node''s subtree. Two passes mirroring
+    go.meta.gen.py''s approach: 1. Attribute access on an imported module alias: yaml.safe_load
+    -> "yaml.safe_load" 2. Bare use of a from-imported name: Path(...) where "from
+    pathlib import Path" -> "pathlib.Path" (filtered out if the origin is stdlib)'
+  references: []
+- name: _dotted_name
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _decorator_name
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _decorators
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _clean_doc
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _has_main_guard
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _suggest_tags
+  kind: function
+  decorators: []
+  description: Suggest tags from file path, imports, and object naming conventions.
+    Returns a sorted list of allowed tag values (see py.meta.schema.yaml). These are
+    suggestions — review and trim before committing the YAML.
+  references: []
+- name: _parse_objects
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _module_name
+  kind: function
+  decorators: []
+  description: Walk up while sibling __init__.py files exist (package convention).
+  references: []
+- name: generate
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: _merge_data
+  kind: function
+  decorators: []
+  description: 'Merge freshly generated data into an existing YAML. Auto fields (always
+    updated from source): module, entrypoint, objects.references, objects.kind, objects.receiver,
+    objects.decorators Description fields (updated only if a docstring exists in source):
+    description (file-level), objects[].description If the new description is empty,
+    the existing value is preserved. Manual fields (never touched): tags, category,
+    used_in, related_nodes, objects[].implements Objects: - New objects (added to
+    source) -> appended - Removed objects (deleted from source) -> dropped - Existing
+    objects -> merged per field rules above'
+  references: []
+- name: _write_yaml
+  kind: function
+  decorators: []
+  description: ''
+  references: []
+- name: main
+  kind: function
+  decorators: []
+  description: ''
+  references: []

--- a/tools/py.meta.gen.yaml
+++ b/tools/py.meta.gen.yaml
@@ -39,6 +39,7 @@ objects:
   decorators: []
   description: ''
   references: []
+  calls: []
 - name: _parse_imports
   kind: function
   decorators: []
@@ -47,16 +48,23 @@ objects:
     "numpy"} `from pathlib import Path` -> {"Path": "pathlib.Path"} `from . import
     foo`      -> {"foo": ".foo"}  (relative — treated as local/non-stdlib)'
   references: []
+  calls: []
 - name: _is_stdlib
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - target.split
+  - target.startswith
 - name: _iter_subtree
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - stack.extend
+  - stack.pop
 - name: _extract_refs
   kind: function
   decorators: []
@@ -65,31 +73,57 @@ objects:
     -> "yaml.safe_load" 2. Bare use of a from-imported name: Path(...) where "from
     pathlib import Path" -> "pathlib.Path" (filtered out if the origin is stdlib)'
   references: []
+  calls:
+  - _is_stdlib
+  - _iter_subtree
+  - imports.get
 - name: _dotted_name
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _dotted_name
+- name: _extract_calls
+  kind: function
+  decorators: []
+  description: 'Extract non-stdlib function/method calls from the given AST node subtree.
+    Resolves through imports: - yaml.safe_load(...)  -> yaml.safe_load  (from: import
+    yaml) - Path(...)            -> pathlib.Path    (from: from pathlib import Path)
+    - local_func(...)      -> local_func      (same-module, kept for graph edges)'
+  references: []
+  calls:
+  - _is_stdlib
+  - _iter_subtree
+  - imports.get
 - name: _decorator_name
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _dotted_name
 - name: _decorators
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _decorator_name
 - name: _clean_doc
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - doc.strip
+  - line.strip
 - name: _has_main_guard
   kind: function
   decorators: []
   description: ''
   references: []
+  calls: []
 - name: _suggest_tags
   kind: function
   decorators: []
@@ -97,21 +131,48 @@ objects:
     Returns a sorted list of allowed tag values (see py.meta.schema.yaml). These are
     suggestions — review and trim before committing the YAML.
   references: []
+  calls:
+  - filename.endswith
+  - filename.startswith
+  - imports.values
+  - o.split
+  - obj.get
+  - path_str.startswith
+  - tags.add
+  - tags.update
 - name: _parse_objects
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _clean_doc
+  - _decorators
+  - _dotted_name
+  - _extract_calls
+  - _extract_refs
+  - objects.append
 - name: _module_name
   kind: function
   decorators: []
   description: Walk up while sibling __init__.py files exist (package convention).
   references: []
+  calls:
+  - parts.insert
 - name: generate
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _clean_doc
+  - _has_main_guard
+  - _module_name
+  - _parse_imports
+  - _parse_objects
+  - _stdlib_set
+  - _suggest_tags
+  - py_file.read_text
 - name: _merge_data
   kind: function
   decorators: []
@@ -124,13 +185,38 @@ objects:
     source) -> appended - Removed objects (deleted from source) -> dropped - Existing
     objects -> merged per field rules above'
   references: []
+  calls:
+  - merged.get
+  - merged_objects.append
+  - new_data.get
+  - obj.get
+  - old_data.get
+  - old_obj.get
 - name: _write_yaml
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - f.write
+  - yaml.dump
 - name: main
   kind: function
   decorators: []
   description: ''
   references: []
+  calls:
+  - _merge_data
+  - _write_yaml
+  - d.glob
+  - d.rglob
+  - f.relative_to
+  - files.append
+  - o.get
+  - parser.add_argument
+  - parser.parse_args
+  - parser.print_help
+  - py_file.exists
+  - py_file.with_suffix
+  - yaml.safe_load
+  - yaml_file.exists

--- a/tools/releaselib/__init__.yaml
+++ b/tools/releaselib/__init__.yaml
@@ -1,0 +1,10 @@
+---
+module: tools.releaselib.__init__
+description: ''
+tags:
+- builder
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects: []

--- a/tools/releaselib/exceptions.yaml
+++ b/tools/releaselib/exceptions.yaml
@@ -1,0 +1,67 @@
+---
+module: tools.releaselib.exceptions
+description: ''
+tags:
+- builder
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: ReleaseError
+  kind: class
+  decorators: []
+  description: Base exception for all release-related errors.
+  implements:
+  - Exception
+  references: []
+- name: __init__
+  kind: method
+  receiver: ReleaseError
+  decorators: []
+  description: ''
+  references: []
+  calls: []
+- name: GitStateError
+  kind: class
+  decorators: []
+  description: Exception for errors related to the Git repository's state.
+  implements:
+  - ReleaseError
+  references: []
+- name: GitServiceError
+  kind: class
+  decorators: []
+  description: Exception for errors originating from the Git service wrapper.
+  implements:
+  - ReleaseError
+  references: []
+- name: VersionMismatchError
+  kind: class
+  decorators: []
+  description: Exception for version string mismatches or invalid increments.
+  implements:
+  - ReleaseError
+  references: []
+- name: ConfigurationError
+  kind: class
+  decorators: []
+  description: Exception for configuration-related errors (e.g., in project.yaml).
+  implements:
+  - ReleaseError
+  references: []
+- name: VaultServiceError
+  kind: class
+  decorators: []
+  description: Exception for errors originating from the Vault service.
+  implements:
+  - ReleaseError
+  references: []
+- name: ManualInterventionRequired
+  kind: class
+  decorators: []
+  description: Custom exception to signal that the process has stopped gracefully
+    and requires manual user action to continue. This is not a fatal error.
+  implements:
+  - ReleaseError
+  references: []

--- a/tools/releaselib/git_service.yaml
+++ b/tools/releaselib/git_service.yaml
@@ -1,0 +1,159 @@
+---
+module: tools.releaselib.git_service
+description: ''
+tags:
+- builder
+- executor
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: GitService
+  kind: class
+  decorators: []
+  description: A service class to abstract Git command operations. This makes the
+    core logic testable by allowing this service to be mocked.
+  implements: []
+  references: []
+- name: __init__
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: ''
+  references: []
+  calls: []
+- name: _run_raw
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Runs a command and returns raw stdout bytes.
+  references:
+  - .exceptions.GitServiceError
+  calls:
+  - .exceptions.GitServiceError
+- name: run
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Runs a Git command and returns its stripped string output.
+  references: []
+  calls:
+  - raw_output.decode
+  - self._run_raw
+- name: get_current_branch
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Returns the current active branch name.
+  references: []
+  calls:
+  - self.run
+- name: get_status_porcelain
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Returns the output of 'git status --porcelain'.
+  references: []
+  calls:
+  - self.run
+- name: is_dirty
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Returns True if there are uncommitted changes.
+  references: []
+  calls:
+  - self.get_status_porcelain
+- name: is_index_dirty
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Returns True if there are staged changes in the index.
+  references:
+  - .exceptions.GitServiceError
+  calls:
+  - .exceptions.GitServiceError
+- name: get_tags
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Returns a list of tags, optionally filtered by a pattern.
+  references: []
+  calls:
+  - command.append
+  - raw_output.split
+  - self.run
+  - tag.strip
+- name: write_tree
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Runs 'git write-tree' and returns the tree ID.
+  references: []
+  calls:
+  - self.run
+- name: add
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Stages a specific file.
+  references: []
+  calls:
+  - self.run
+- name: archive_tree_bytes
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Runs 'git archive' and returns the raw bytes of the tar archive.
+  references: []
+  calls:
+  - command.append
+  - self._run_raw
+- name: assert_clean_index
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Checks if the Git index is clean (no staged changes). Raises GitStateError
+    if staged changes are detected.
+  references:
+  - .exceptions.GitServiceError
+  - .exceptions.GitStateError
+  calls:
+  - .exceptions.GitServiceError
+  - .exceptions.GitStateError
+- name: checkout
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Checks out a Git branch, optionally creating it.
+  references: []
+  calls:
+  - command.append
+  - self.run
+- name: create_branch
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Creates a new Git branch.
+  references: []
+  calls:
+  - self.run
+- name: delete_branch
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Deletes a Git branch.
+  references: []
+  calls:
+  - self.run
+- name: merge
+  kind: method
+  receiver: GitService
+  decorators: []
+  description: Merges a Git branch into the current branch.
+  references: []
+  calls:
+  - command.append
+  - command.extend
+  - self.run

--- a/tools/releaselib/vault_service.yaml
+++ b/tools/releaselib/vault_service.yaml
@@ -1,0 +1,58 @@
+---
+module: tools.releaselib.vault_service
+description: ''
+tags:
+- builder
+category: []
+used_in: []
+entrypoint: false
+related_nodes: []
+objects:
+- name: VaultService
+  kind: class
+  decorators: []
+  description: A service class to abstract Vault operations, including signing and
+    secret retrieval.
+  implements: []
+  references: []
+- name: __init__
+  kind: method
+  receiver: VaultService
+  decorators: []
+  description: ''
+  references:
+  - .exceptions.VaultServiceError
+  calls:
+  - .exceptions.VaultServiceError
+- name: sign
+  kind: method
+  receiver: VaultService
+  decorators: []
+  description: Signs a pre-hashed, base64-encoded digest using Vault's Transit Engine.
+  references:
+  - .exceptions.VaultServiceError
+  - requests.exceptions
+  - requests.post
+  calls:
+  - .exceptions.VaultServiceError
+  - requests.post
+  - response.json
+  - response.raise_for_status
+  - response_data.get
+  - signature.startswith
+- name: get_certificate
+  kind: method
+  receiver: VaultService
+  decorators: []
+  description: Retrieves a certificate (or any secret) from Vault's KV v2 engine.
+    In dry-run mode, returns a placeholder certificate.
+  references:
+  - .exceptions.VaultServiceError
+  - requests.exceptions
+  - requests.get
+  calls:
+  - .exceptions.VaultServiceError
+  - requests.get
+  - response.json
+  - response.raise_for_status
+  - response_data.get


### PR DESCRIPTION
## Summary

- **calls graph (Go)**: AST-extracted function call edges with type resolution — bare call names matched against typed refs (`Set` → `cabinet.Cabinet.Set`)
- **Python call graph**: `_extract_calls` in `py.meta.gen.py` using `ast.Call` nodes — resolves cross-module calls through imports (`yaml.safe_load`, `langdetect.detect`) and tracks same-module calls
- **Interface tracking**: `_detect_implements` in `go.meta.gen.py` — cross-file method-set inclusion detection; `cabinetService → Cabinet`, `Recorder → ExecutionRecorder`, etc. 29 structs auto-detected
- **`implements` edges in KB graph**: `make_source.py` emits `implements` edges (48 total) from companion YAML `implements` field
- **`is_test` property** on KB nodes for test/production separation
- **p_venv exclusion**: `EXCLUDE_DIRS` in both `make_source.py` and `kb_watch.py`
- **Bug fix**: `create_bm25_inverted_index` now returns `[{chunk_id, score}]` dicts (was plain strings)
- **Bug fix**: node ID generation handles short IDs (`c1`) without producing empty suffix

## Edge type summary (CIC-Relay KB after re-index)

| Type | Count |
|---|---|
| `refers-to` | 2,398 |
| `references` | 1,765 |
| `calls` | 1,032 |
| `implements` | 48 |

## Test plan

- [x] 37/37 unit tests pass (`pytest tests/test_tools/test_make_source.py tests/test_tools/test_mcp_server.py`)
- [x] KB re-indexed successfully on CIC-Relay (2,399 nodes, 5,243 edges)
- [x] Spot-checked `implements` edges: `mockCabinet→Cabinet`, `WasmManager→wasmManager`, `mockModuleStore→WorkflowStore`
- [x] Spot-checked `calls` edges: `Activate→CanonicalizeSetPayload`, `registerNativeComponents→PutModule`